### PR TITLE
Expand capabilities of sockets

### DIFF
--- a/RLBotCS/Conversion/FlatToCommand.cs
+++ b/RLBotCS/Conversion/FlatToCommand.cs
@@ -67,33 +67,35 @@ namespace RLBotCS.Conversion
             return command;
         }
 
-        static public string MakeGameSpeedCommand(GameSpeedOption gameSpeed)
+        static public string MakeGameSpeedCommand(float gameSpeed)
         {
-            var command = "Set WorldInfo TimeDilation ";
-            var speed = gameSpeed switch
+            return "Set WorldInfo TimeDilation " + gameSpeed.ToString();
+        }
+
+        static public string MakeGameSpeedCommandFromOption(GameSpeedOption gameSpeed)
+        {
+            return MakeGameSpeedCommand(gameSpeed switch
             {
                 GameSpeedOption.Slo_Mo => 0.5f,
                 GameSpeedOption.Time_Warp => 1.5f,
                 _ => 1.0f,
-            };
-            command += speed.ToString();
-
-            return command;
+            });
         }
 
-        static public string MakeGravityCommand(GravityOption gravityOption)
+        static public string MakeGravityCommand(float gravity)
         {
-            var command = "Set WorldInfo WorldGravityZ ";
-            var gravity = gravityOption switch
+            return "Set WorldInfo WorldGravityZ " + gravity.ToString();
+        }
+
+        static public string MakeGravityCommandFromOption(GravityOption gravityOption)
+        {
+            return MakeGravityCommand(gravityOption switch
             {
                 GravityOption.Low => -325,
                 GravityOption.High => -1137.5f,
                 GravityOption.Super_High => -3250,
                 _ => -650,
-            };
-            command += gravity.ToString();
-
-            return command;
+            });
         }
 
         static public string MakeAutoSaveReplayCommand()

--- a/RLBotCS/Conversion/FlatToModel.cs
+++ b/RLBotCS/Conversion/FlatToModel.cs
@@ -94,5 +94,35 @@ namespace RLBotSecret.Conversion
                 secondaryColorLookup = secondaryColor
             };
         }
+
+        static internal Vector3 DesiredToVector(rlbot.flat.Vector3PartialT vec)
+        {
+            return new Vector3() {
+                x = vec.X?.Val ?? 0,
+                y = vec.Y?.Val ?? 0,
+                z = vec.Z?.Val ?? 0
+            };
+        }
+
+        static internal Rotator DesiredToRotator(rlbot.flat.RotatorPartialT rot)
+        {
+            return new Rotator() {
+                pitch = rot.Pitch?.Val ?? 0,
+                yaw = rot.Yaw?.Val ?? 0,
+                roll = rot.Roll?.Val ?? 0
+            };
+        }
+
+        static internal Physics DesiredToPhysics(rlbot.flat.DesiredPhysicsT p)
+        {
+            return new Physics()
+            {
+                location = DesiredToVector(p.Location),
+                rotation = DesiredToRotator(p.Rotation),
+                velocity = DesiredToVector(p.Velocity),
+                angularVelocity = DesiredToVector(p.AngularVelocity),
+            };
+        }
+
     }
 }

--- a/RLBotCS/GameState/GameState.cs
+++ b/RLBotCS/GameState/GameState.cs
@@ -109,6 +109,11 @@ namespace RLBotCS.GameState
                         car.scoreInfo.demolitions = playerAccolade.demolitions;
                     }
                 }
+                else if (message is BallSpawn ballSpawn)
+                {
+                    gameTickPacket.ball.actorId = ballSpawn.actorId;
+                    gameTickPacket.ball.shape = ballSpawn.collisionShape;
+                }
                 // TODO: lots more message handlers.
             }
         }
@@ -175,9 +180,9 @@ namespace RLBotCS.GameState
         }
 
 
-        public bool NotMatchEnded()
+        public bool MatchEnded()
         {
-            return gameTickPacket.gameState != GameStateType.Ended;
+            return gameTickPacket.gameState == GameStateType.Ended;
         }
     }
 }

--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -39,7 +39,7 @@ foreach (var messageClump in messenger)
     gameState.applyMessage(messageBundle);
 
     // this helps to wait for a new map to load 
-    if (gameState.NotMatchEnded())
+    if (!gameState.MatchEnded())
     {
         matchStarter.applyMessageBundle(messageBundle);
     }

--- a/RLBotCS/RLBotPacket/Ball.cs
+++ b/RLBotCS/RLBotPacket/Ball.cs
@@ -1,4 +1,5 @@
-﻿using RLBotModels.Phys;
+﻿using RLBotModels.Message;
+using RLBotModels.Phys;
 
 namespace RLBotCS.RLBotPacket
 {
@@ -6,5 +7,14 @@ namespace RLBotCS.RLBotPacket
     {
         public Physics physics;
         public BallTouch latestTouch;
+        public CollisionShapeUnion shape = new()
+        {
+            Type = CollisionShape.SphereShape,
+            Value = new SphereShape()
+            {
+                Diameter = 91.25f,
+            }
+        };
+        public ushort actorId;
     }
 }

--- a/RLBotCS/RLBotPacket/GameTickPacket.cs
+++ b/RLBotCS/RLBotPacket/GameTickPacket.cs
@@ -71,14 +71,31 @@ namespace RLBotCS.RLBotPacket
                 }
             };
 
-            rlbot.flat.CollisionShapeUnion collisionShape = new() {
-                Type = rlbot.flat.CollisionShape.SphereShape,
-                Value = new rlbot.flat.SphereShapeT() {
+            rlbot.flat.CollisionShapeUnion collisionShape = ball.shape.Type switch
+            {
+                CollisionShape.BoxShape => rlbot.flat.CollisionShapeUnion.FromBoxShape(new()
+                {
+                    Length = ball.shape.As<BoxShape>().Length,
+                    Width = ball.shape.As<BoxShape>().Width,
+                    Height = ball.shape.As<BoxShape>().Height,
+                }),
+                CollisionShape.SphereShape => rlbot.flat.CollisionShapeUnion.FromSphereShape(new()
+                {
+                    Diameter = ball.shape.As<SphereShape>().Diameter,
+                }),
+                CollisionShape.CylinderShape => rlbot.flat.CollisionShapeUnion.FromCylinderShape(new()
+                {
+                    Diameter = ball.shape.As<CylinderShape>().Diameter,
+                    Height = ball.shape.As<CylinderShape>().Height,
+                }),
+                _ => rlbot.flat.CollisionShapeUnion.FromSphereShape(new()
+                {
                     Diameter = 91.25f * 2,
-                }
+                }),
             };
 
-            rlbot.flat.BallInfoT ballInfo = new() {
+            rlbot.flat.BallInfoT ballInfo = new()
+            {
                 Physics = ballPhysics,
                 LatestTouch = lastTouch,
                 Shape = collisionShape,

--- a/RLBotCS/Server/DataType.cs
+++ b/RLBotCS/Server/DataType.cs
@@ -20,12 +20,9 @@ namespace RLBotCS.Server
         // Sent once when a match starts, or when you first connect.
         MatchSettings,
         PlayerInput,
-        // Deprecated, related to https://github.com/RLBot/RLBot/wiki/Remote-RLBot
-        ActorMappingData,
-        // Deprecated, related to https://github.com/RLBot/RLBot/wiki/Remote-RLBot.
-        ComputerId,
         DesiredGameState,
         RenderGroup,
+        RemoveRenderGroup,
         QuickChat,
         // Sent every time the ball diverges from the previous prediction,
         // or when the previous prediction no longer gives a full 6 seconds into the future
@@ -33,6 +30,6 @@ namespace RLBotCS.Server
         // Clients must send this after connecting to the socket.
         ReadyMessage,
         // List of messages, having one of several possible sub-types.
-        MessagePacket
+        MessagePacket,
     };
 }

--- a/RLBotCS/Server/FlatbufferServer.cs
+++ b/RLBotCS/Server/FlatbufferServer.cs
@@ -7,7 +7,6 @@ using System.Net.Sockets;
 
 namespace RLBotCS.Server
 {
-
     /**
      * Taken from https://codinginfinite.com/multi-threaded-tcp-server-core-example-csharp/
      */
@@ -69,6 +68,7 @@ namespace RLBotCS.Server
                 {
                     continue;
                 }
+
                 if (session.NeedsIntroData)
                 {
                     if (matchStarter.GetMatchSettings() is TypedPayload matchSettings)
@@ -76,6 +76,13 @@ namespace RLBotCS.Server
                         session.SendIntroData(matchSettings, gameState);
                     }
                 }
+
+                if (gameState.MatchEnded())
+                {
+                    session.RemoveRenders();
+                }
+
+                session.SetBallActorId(gameState.gameTickPacket.ball.actorId);
 
                 try
                 {


### PR DESCRIPTION
- Remove deprecated `ActorMappingData` and `ComputerId` from possible data types in sockets
- Add `RemoveRenderGroup` data type for sockets
- Support rendering over sockets
- Support mostly complete state setting over sockets
- Make the human player spectate the match upon loading in

Rendering in v5 is aiming to be more efficient than in v4:
- Rendering doesn't clear every tick
- Rendering is tracked every tick on a per-bot basis
- When a bot disconnects, its renders get cleared
- When a match ends, all rendering is cleared
- A bot can send `RemoveRenderGroup` over sockets with the original render group ID to remove a render
- The old render gets removed when a render of the same group ID is sent from the same bot
- PolyLine rendering actually works now and saves a bit of data when sending over sockets

This allows for large complex renders that don't need to be re-drawn every frame. If a bot _does_ redraw something every frame, then as long as it has the same render group ID it will exhibit the same behavior as v4.

I hope fun stuff will be made with the new v5 rendering :)

In addition, *text rendering* is getting some fun goodies:
- Proper, non-hacky background colors!!!
- Vertical and horizontal alignment options! You can now center your multi-line text renders!