### PR TITLE
Add proccess arg for game port & don't launch game when specified

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,34 +8,44 @@ using RLBotCS.Server.FlatbuffersMessage;
 var logger = Logging.GetLogger("Main");
 
 int rlbotSocketsPort;
+int gamePort;
+
 try
 {
+    // Parse RLBot sockets port
     rlbotSocketsPort = args.Length > 0 ? int.Parse(args[0]) : LaunchManager.RlbotSocketsPort;
 
-    // additional validation to ensure it's a valid port number
-    if (rlbotSocketsPort < 0)
+    // Validate RLBot sockets port
+    if (rlbotSocketsPort < 0 || rlbotSocketsPort > 65535)
     {
-        throw new FormatException();
+        throw new ArgumentOutOfRangeException(
+            nameof(rlbotSocketsPort),
+            "Port number must be between 0 and 65535."
+        );
     }
-    else if (rlbotSocketsPort > 65535)
+
+    // Parse game port
+    gamePort =
+        args.Length > 1
+            ? int.Parse(args[1])
+            : LaunchManager.FindUsableGamePort(rlbotSocketsPort);
+
+    // Validate game port
+    if (gamePort < 0 || gamePort > 65535)
     {
-        throw new OverflowException();
+        throw new ArgumentOutOfRangeException(
+            nameof(gamePort),
+            "Port number must be between 0 and 65535."
+        );
     }
 }
-catch (FormatException)
+catch (ArgumentOutOfRangeException ex)
 {
-    logger.LogError("Invalid port number provided. Please provide a valid port number.");
-    return;
-}
-catch (OverflowException)
-{
-    logger.LogError("Port number provided is too large. Please provide a valid port number.");
+    logger.LogError(ex.Message);
     return;
 }
 
 logger.LogInformation("Server will start on port " + rlbotSocketsPort);
-
-int gamePort = LaunchManager.FindUsableGamePort(rlbotSocketsPort);
 logger.LogInformation("Waiting for Rocket League to connect on port " + gamePort);
 
 // Set up the handler to use bridge to talk with the game

--- a/RLBotCS/ManagerTools/LaunchManager.cs
+++ b/RLBotCS/ManagerTools/LaunchManager.cs
@@ -197,7 +197,7 @@ internal static class LaunchManager
 
     public static void LaunchRocketLeague(
         rlbot.flat.Launcher launcherPref,
-        string gamePath,
+        string extraArg,
         int gamePort
     )
     {
@@ -206,16 +206,16 @@ internal static class LaunchManager
             {
                 case rlbot.flat.Launcher.Steam:
                     string steamPath = GetWindowsSteamPath();
-                    Process rocketLeague = new();
-                    rocketLeague.StartInfo.FileName = steamPath;
-                    rocketLeague.StartInfo.Arguments =
+                    Process steam = new();
+                    steam.StartInfo.FileName = steamPath;
+                    steam.StartInfo.Arguments =
                         $"-applaunch {SteamGameId} "
                         + string.Join(" ", GetIdealArgs(gamePort));
 
                     Logger.LogInformation(
-                        $"Starting Rocket League with args {steamPath} {rocketLeague.StartInfo.Arguments}"
+                        $"Starting Rocket League with args {steamPath} {steam.StartInfo.Arguments}"
                     );
-                    rocketLeague.Start();
+                    steam.Start();
                     break;
                 case rlbot.flat.Launcher.Epic:
                     bool nonRLBotGameRunning = IsRocketLeagueRunning();
@@ -287,13 +287,20 @@ internal static class LaunchManager
 
                     break;
                 case rlbot.flat.Launcher.Custom:
-                    if (gamePath.ToLower() == "legendary")
+                    if (extraArg.ToLower() == "legendary")
                     {
                         LaunchGameViaLegendary();
                         return;
                     }
+                    else if (extraArg.ToLower() == "")
+                    {
+                        Logger.LogInformation(
+                            "Custom launcher specified without any extra arguments. Not launching Rocket League."
+                        );
+                        return;
+                    }
 
-                    throw new NotSupportedException("Unexpected launcher. Use Steam.");
+                    throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
             }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             switch (launcherPref)
@@ -312,15 +319,24 @@ internal static class LaunchManager
                     rocketLeague.Start();
                     break;
                 case rlbot.flat.Launcher.Epic:
-                    throw new NotSupportedException("Epic Games not supported on Linux.");
+                    throw new NotSupportedException(
+                        "Epic Games Store is not directly supported on Linux."
+                    );
                 case rlbot.flat.Launcher.Custom:
-                    if (gamePath.ToLower() == "legendary")
+                    if (extraArg.ToLower() == "legendary")
                     {
                         LaunchGameViaLegendary();
                         return;
                     }
+                    else if (extraArg.ToLower() == "")
+                    {
+                        Logger.LogInformation(
+                            "Custom launcher specified without any extra arguments. Not launching Rocket League."
+                        );
+                        return;
+                    }
 
-                    throw new NotSupportedException("Unexpected launcher. Use Steam.");
+                    throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
             }
         else
             throw new PlatformNotSupportedException(

--- a/RLBotCS/ManagerTools/LaunchManager.cs
+++ b/RLBotCS/ManagerTools/LaunchManager.cs
@@ -292,15 +292,10 @@ internal static class LaunchManager
                         LaunchGameViaLegendary();
                         return;
                     }
-                    else if (extraArg.ToLower() == "")
-                    {
-                        Logger.LogInformation(
-                            "Custom launcher specified without any extra arguments. Not launching Rocket League."
-                        );
-                        return;
-                    }
 
                     throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
+                case rlbot.flat.Launcher.NoLaunch:
+                    break;
             }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             switch (launcherPref)
@@ -328,15 +323,10 @@ internal static class LaunchManager
                         LaunchGameViaLegendary();
                         return;
                     }
-                    else if (extraArg.ToLower() == "")
-                    {
-                        Logger.LogInformation(
-                            "Custom launcher specified without any extra arguments. Not launching Rocket League."
-                        );
-                        return;
-                    }
 
                     throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
+                case rlbot.flat.Launcher.NoLaunch:
+                    break;
             }
         else
             throw new PlatformNotSupportedException(

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -51,6 +51,9 @@ internal class BridgeHandler(
                 }
 
                 // reset the counter that lets us know if we're sending too many bytes
+                // technically this resets every time Rocket League renders a frame,
+                // but we don't know when that is. Since every message from the game
+                // means _at least_ one frame was rendered, this works good enough.
                 messenger.ResetByteCount();
 
                 float prevTime = _context.GameState.SecondsElapsed;


### PR DESCRIPTION
- 2nd argument passed is always the game port
- Don't try to launch Rocket League when `launcher = "Custom"` and `launcher_arg` is empty