### PR TITLE
Fix config inconsistencies

### DIFF
--- a/RLBotCS/Conversion/FlatToCommand.cs
+++ b/RLBotCS/Conversion/FlatToCommand.cs
@@ -142,14 +142,14 @@ static class FlatToCommand
             _ => throw new ArgumentOutOfRangeException(nameof(option), option, null),
         };
 
-    private static string MapBoost(BoostMutator option) =>
+    private static string MapBoostAmount(BoostAmountMutator option) =>
         option switch
         {
-            BoostMutator.NormalBoost => "",
-            BoostMutator.UnlimitedBoost => "UnlimitedBooster",
-            BoostMutator.SlowRecharge => "SlowRecharge",
-            BoostMutator.RapidRecharge => "RapidRecharge",
-            BoostMutator.NoBoost => "NoBooster",
+            BoostAmountMutator.NormalBoost => "",
+            BoostAmountMutator.UnlimitedBoost => "UnlimitedBooster",
+            BoostAmountMutator.SlowRecharge => "SlowRecharge",
+            BoostAmountMutator.RapidRecharge => "RapidRecharge",
+            BoostAmountMutator.NoBoost => "NoBooster",
             _ => throw new ArgumentOutOfRangeException(nameof(option), option, null),
         };
 
@@ -292,7 +292,7 @@ static class FlatToCommand
         command += GetOption(MapBallWeight(mutatorSettings.BallWeight));
         command += GetOption(MapBallSize(mutatorSettings.BallSize));
         command += GetOption(MapBallBounciness(mutatorSettings.BallBounciness));
-        command += GetOption(MapBoost(mutatorSettings.Boost));
+        command += GetOption(MapBoostAmount(mutatorSettings.BoostAmount));
         command += GetOption(MapRumble(mutatorSettings.Rumble));
         command += GetOption(MapBoostStrength(mutatorSettings.BoostStrength));
         command += GetOption(MapGravity(mutatorSettings.Gravity));

--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.FlatbuffersMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.5.0");
+    Console.WriteLine("RLBotServer v5.beta.4.3");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.FlatbuffersMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.4.2");
+    Console.WriteLine("RLBotServer v5.beta.5.0");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -56,6 +56,7 @@ public class ConfigParser
         public const string AgentName = "name";
         public const string AgentLoadoutFile = "loadout_file";
         public const string AgentConfigFile = "config_file";
+        public const string AgentConfigFileOld = "config";
         public const string AgentSettingsTable = "settings";
         public const string AgentAgentId = "agent_id";
         public const string AgentRootDir = "root_dir";
@@ -277,6 +278,12 @@ public class ConfigParser
         };
 
         string configPath = useConfig ? GetValue(table, Fields.AgentConfigFile, "") : "";
+        // FIXME: Remove in v5.beta.5.0+
+        if (configPath == "" && table.ContainsKey(Fields.AgentConfigFileOld))
+        {
+            Logger.LogWarning($"In {_context}: '{Fields.AgentConfigFileOld}' is deprecated. Use '{Fields.AgentConfigFile}' instead.");
+            configPath = GetValue(table, Fields.AgentConfigFileOld, "");
+        }
 
         PlayerConfigurationT player;
         if (useConfig && configPath == "" && variety.Type == PlayerClass.CustomBot)

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -38,7 +38,7 @@ public class ConfigParser
         public const string MutatorsBallWeight = "ball_weight";
         public const string MutatorsBallSize = "ball_size";
         public const string MutatorsBallBounciness = "ball_bounciness";
-        public const string MutatorsBoost = "boost_amount";
+        public const string MutatorsBoostAmount = "boost_amount";
         public const string MutatorsRumble = "rumble";
         public const string MutatorsBoostStrength = "boost_strength";
         public const string MutatorsGravity = "gravity";
@@ -486,7 +486,7 @@ public class ConfigParser
                 Fields.MutatorsBallBounciness,
                 BallBouncinessMutator.Default
             ),
-            Boost = GetEnum(mutatorTable, Fields.MutatorsBoost, BoostMutator.NormalBoost),
+            BoostAmount = GetEnum(mutatorTable, Fields.MutatorsBoostAmount, BoostAmountMutator.NormalBoost),
             Rumble = GetEnum(mutatorTable, Fields.MutatorsRumble, RumbleMutator.NoRumble),
             BoostStrength = GetEnum(
                 mutatorTable,

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -55,7 +55,7 @@ public class ConfigParser
         public const string AgentSkill = "skill";
         public const string AgentName = "name";
         public const string AgentLoadoutFile = "loadout_file";
-        public const string AgentConfigFile = "config";
+        public const string AgentConfigFile = "config_file";
         public const string AgentSettingsTable = "settings";
         public const string AgentAgentId = "agent_id";
         public const string AgentRootDir = "root_dir";

--- a/RLBotCS/ManagerTools/MatchStarter.cs
+++ b/RLBotCS/ManagerTools/MatchStarter.cs
@@ -298,7 +298,7 @@ class MatchStarter(ChannelWriter<IBridgeMessage> bridge, int gamePort, int rlbot
             || lastMutators.BallWeight != mutators.BallWeight
             || lastMutators.BallSize != mutators.BallSize
             || lastMutators.BallBounciness != mutators.BallBounciness
-            || lastMutators.Boost != mutators.Boost
+            || lastMutators.BoostAmount != mutators.BoostAmount
             || lastMutators.Rumble != mutators.Rumble
             || lastMutators.BoostStrength != mutators.BoostStrength
             || lastMutators.Demolish != mutators.Demolish

--- a/RLBotCSTests/ConfigParserTest.cs
+++ b/RLBotCSTests/ConfigParserTest.cs
@@ -78,7 +78,7 @@ public class ConfigParserTest
         Assert.AreEqual(emptyMutS.BallWeight, defaultMutS.BallWeight);
         Assert.AreEqual(emptyMutS.BallSize, defaultMutS.BallSize);
         Assert.AreEqual(emptyMutS.BallBounciness, defaultMutS.BallBounciness);
-        Assert.AreEqual(emptyMutS.Boost, defaultMutS.Boost);
+        Assert.AreEqual(emptyMutS.BoostAmount, defaultMutS.BoostAmount);
         Assert.AreEqual(emptyMutS.Rumble, defaultMutS.Rumble);
         Assert.AreEqual(emptyMutS.BoostStrength, defaultMutS.BoostStrength);
         Assert.AreEqual(emptyMutS.Gravity, defaultMutS.Gravity);


### PR DESCRIPTION
- Renames `cars[i].config` to `cars[i].config_file` to be in line with other fields for files
- Renames `mutator.boost` to `mutator.boost_amount`