### PR TITLE
Don't delay render removals when possible

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.4.9");
+    Console.WriteLine("RLBotServer v5.beta.4.10");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -54,6 +54,8 @@ class BridgeHandler(
                 // but we don't know when that is. Since every message from the game
                 // means _at least_ one frame was rendered, this works good enough.
                 messenger.ResetByteCount();
+                // reset the counter that lets us know if we're sending too many clear messages
+                _context.RenderingMgmt.ResetClearCount();
 
                 float prevTime = _context.GameState.SecondsElapsed;
                 _context.GameState = MessageHandler.CreateUpdatedState(


### PR DESCRIPTION
This caused both the old render and the new render to be visible.

Example:

![image](https://github.com/user-attachments/assets/ca278c36-e584-49cc-b4ca-8b9c04375a3e)
