### PR TITLE
Fix renders not clearing sometimes

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.5.1");
+    Console.WriteLine("RLBotServer v5.beta.5.2");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/ManagerTools/Rendering.cs
+++ b/RLBotCS/ManagerTools/Rendering.cs
@@ -256,9 +256,6 @@ public class Rendering(TcpMessenger tcpMessenger)
 
     public bool SendRenderClears()
     {
-        if (_RenderClearQueue.Count == 0)
-            return true;
-
         while (_RenderClearQueue.Count > 0 && _numClears < MaxClearsPerTick)
         {
             var renderItem = _RenderClearQueue.Dequeue();


### PR DESCRIPTION
I noticed that the performance monitor wasn't going away since the most recent update. This is because `_renderingSender.Send();` wasn't being called if there was nothing queued, even though we had manually queued stuff and `_numClears` was > 0