### PR TITLE
Allow match managers to send match comms

### DIFF
--- a/RLBotCS/Conversion/ColorSwatches.cs
+++ b/RLBotCS/Conversion/ColorSwatches.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using rlbot.flat;
+using Color = System.Drawing.Color;
 
 namespace RLBotCS.Conversion;
 
@@ -6,7 +7,7 @@ static class ColorSwatches
 {
     internal static Color GetPrimary(uint colorId, uint team)
     {
-        var swatches = team == 0 ? BlueSwatches : OrangeSwatches;
+        var swatches = team == Team.Blue ? BlueSwatches : OrangeSwatches;
         return Color.FromArgb(
             255,
             swatches[colorId, 0],

--- a/RLBotCS/Conversion/GameStateToFlat.cs
+++ b/RLBotCS/Conversion/GameStateToFlat.cs
@@ -111,8 +111,8 @@ static class GameStateToFlat
 
         List<TeamInfoT> teams =
         [
-            new() { TeamIndex = 0, Score = gameState.TeamScores.blue },
-            new() { TeamIndex = 1, Score = gameState.TeamScores.orange },
+            new() { TeamIndex = Team.Blue, Score = gameState.TeamScores.blue },
+            new() { TeamIndex = Team.Orange, Score = gameState.TeamScores.orange },
         ];
 
         List<BoostPadStateT> boostStates = gameState

--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.6.0");
+    Console.WriteLine("RLBotServer v5.beta.6.1");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/ManagerTools/BallPredictor.cs
+++ b/RLBotCS/ManagerTools/BallPredictor.cs
@@ -147,7 +147,7 @@ public static partial class BallPredictor
                 if (currentTime - latestTouch.GameSeconds < 0.1)
                 {
                     // Target goal is the opposite of the last touch
-                    SetHeatseekerTarget(touchingTeam == 1 ? (byte)0 : (byte)1);
+                    SetHeatseekerTarget(touchingTeam == Team.Blue ? (byte)Team.Orange : (byte)Team.Blue);
                 }
                 else if (GetHeatseekerTargetY() == 0 || MathF.Abs(ball.Location.Y) >= 4820)
                 {

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -418,7 +418,7 @@ public class ConfigParser
         TomlTable loadoutToml = LoadTomlFile(loadoutPath);
 
         string teamLoadoutString =
-            team == 0 ? Fields.LoadoutBlueTable : Fields.LoadoutOrangeTable;
+            team == Team.Blue ? Fields.LoadoutBlueTable : Fields.LoadoutOrangeTable;
         TomlTable teamLoadout = GetValue<TomlTable>(loadoutToml, teamLoadoutString, []);
         using (_context.Begin(teamLoadoutString, ConfigContextTracker.Type.Link))
         {

--- a/RLBotCS/ManagerTools/ConfigValidator.cs
+++ b/RLBotCS/ManagerTools/ConfigValidator.cs
@@ -63,7 +63,7 @@ public static class ConfigValidator
             using var _ = ctx.Begin($"{Fields.CarsList}[{i}]");
             var player = players[i];
 
-            if (player.Team != 0 && player.Team != 1)
+            if (player.Team != Team.Blue && player.Team != Team.Orange)
             {
                 Logger.LogError(
                     $"Invalid {ctx.ToStringWithEnd(Fields.AgentTeam)} of '{player.Team}'. "

--- a/RLBotCS/ManagerTools/QuickChat.cs
+++ b/RLBotCS/ManagerTools/QuickChat.cs
@@ -73,7 +73,7 @@ public class QuickChat
 
         foreach (var (_, name, chat) in _chats)
         {
-            var textColor = chat.Team == 0 ? BlueColor : OrangeColor;
+            var textColor = chat.Team == Team.Blue ? BlueColor : OrangeColor;
 
             String2DT message = new()
             {

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -19,7 +19,7 @@ class BridgeHandler(
     private const int MAX_TICK_SKIP = 1;
     private readonly BridgeContext _context = new(writer, reader, messenger);
 
-    private async Task HandleIncomingMessages()
+    private async Task HandleInternalMessages()
     {
         await foreach (IBridgeMessage message in _context.Reader.ReadAllAsync())
         {
@@ -148,7 +148,7 @@ class BridgeHandler(
     }
 
     public void BlockingRun() =>
-        Task.WhenAny(Task.Run(HandleIncomingMessages), Task.Run(HandleServer)).Wait();
+        Task.WhenAny(Task.Run(HandleInternalMessages), Task.Run(HandleServer)).Wait();
 
     public void Cleanup()
     {

--- a/RLBotCS/Server/FlatBuffersSession.cs
+++ b/RLBotCS/Server/FlatBuffersSession.cs
@@ -231,25 +231,38 @@ class FlatBuffersSession
                 await _bridge.WriteAsync(new Input(playerInputMsg));
                 break;
 
-            case DataType.MatchComms when _wantsComms:
+            case DataType.MatchComms:
                 var matchComms = MatchComm.GetRootAsMatchComm(byteBuffer).UnPack();
 
-                // ensure the team is correctly set
-                matchComms.Team = _team;
-
-                // ensure the provided index is a bot we control,
-                // and map the index to the spawn id
-                PlayerIdPair? playerIdPair = _playerIdPairs.FirstOrDefault(idPair =>
-                    idPair.Index == matchComms.Index
-                );
-
-                if (playerIdPair is PlayerIdPair pInfo && pInfo.SpawnId is int pSpawnId)
+                if (_agentId != "")
                 {
-                    await _rlbotServer.WriteAsync(
-                        new SendMatchComm(_clientId, pSpawnId, matchComms)
+                    // ensure the team is correctly set
+                    matchComms.Team = _team;
+
+                    // ensure the provided index is a bot we control,
+                    // and map the index to the spawn id
+                    PlayerIdPair? playerIdPair = _playerIdPairs.FirstOrDefault(idPair =>
+                        idPair.Index == matchComms.Index
                     );
 
-                    await _bridge.WriteAsync(new ShowQuickChat(matchComms));
+                    if (playerIdPair != null)
+                    {
+                        await _rlbotServer.WriteAsync(
+                            new SendMatchComm(_clientId, matchComms)
+                        );
+
+                        await _bridge.WriteAsync(new ShowQuickChat(matchComms));
+                    }
+                }
+                else if (_agentId == "" && _connectionEstablished)
+                {
+                    // Client is a match manager.
+                    // We allow these to send match comms to bots/scripts too, e.g. for briefing.
+                    // They will not appear in quick chat.
+                    matchComms.Index = (uint)_clientId;
+                    matchComms.Team = 3;
+                    matchComms.TeamOnly = false;
+                    await _rlbotServer.WriteAsync(new SendMatchComm(_clientId, matchComms));
                 }
 
                 break;
@@ -319,7 +332,7 @@ class FlatBuffersSession
         }
     }
 
-    private async Task HandleIncomingMessages()
+    private async Task HandleInternalMessages()
     {
         await foreach (SessionMessage message in _incomingMessages.Reader.ReadAllAsync())
             switch (message)
@@ -457,7 +470,7 @@ class FlatBuffersSession
         {
             try
             {
-                await HandleIncomingMessages();
+                await HandleInternalMessages();
             }
             catch (Exception e)
             {

--- a/RLBotCS/Server/FlatBuffersSession.cs
+++ b/RLBotCS/Server/FlatBuffersSession.cs
@@ -65,7 +65,7 @@ class FlatBuffersSession
     private bool _renderingIsEnabled;
 
     private string _agentId = string.Empty;
-    private uint _team;
+    private uint _team = Team.Other;
     private List<PlayerIdPair> _playerIdPairs = new();
     private bool _sessionForceClosed;
     private bool _closed;
@@ -254,13 +254,13 @@ class FlatBuffersSession
                         await _bridge.WriteAsync(new ShowQuickChat(matchComms));
                     }
                 }
-                else if (_agentId == "" && _connectionEstablished && _stateSettingIsEnabled)
+                else if (_agentId == "" && _connectionEstablished)
                 {
                     // Client is a match manager.
                     // We allow these to send match comms to bots/scripts too, e.g. for briefing.
                     // They will not appear in quick chat.
                     matchComms.Index = 0;
-                    matchComms.Team = 3;
+                    matchComms.Team = Team.Other;
                     matchComms.TeamOnly = false;
                     await _rlbotServer.WriteAsync(new SendMatchComm(_clientId, matchComms));
                 }

--- a/RLBotCS/Server/FlatBuffersSession.cs
+++ b/RLBotCS/Server/FlatBuffersSession.cs
@@ -254,12 +254,12 @@ class FlatBuffersSession
                         await _bridge.WriteAsync(new ShowQuickChat(matchComms));
                     }
                 }
-                else if (_agentId == "" && _connectionEstablished)
+                else if (_agentId == "" && _connectionEstablished && _stateSettingIsEnabled)
                 {
                     // Client is a match manager.
                     // We allow these to send match comms to bots/scripts too, e.g. for briefing.
                     // They will not appear in quick chat.
-                    matchComms.Index = (uint)_clientId;
+                    matchComms.Index = 0;
                     matchComms.Team = 3;
                     matchComms.TeamOnly = false;
                     await _rlbotServer.WriteAsync(new SendMatchComm(_clientId, matchComms));

--- a/RLBotCS/Server/ServerMessage/SendMatchComm.cs
+++ b/RLBotCS/Server/ServerMessage/SendMatchComm.cs
@@ -31,7 +31,7 @@ record SendMatchComm(int ClientId, MatchCommT MatchComm) : IServerMessage
                 var player = context.LastTickPacket.Players.Find(player =>
                     player.SpawnId == spawnId
                 );
-                if (message.Message.Team == 2)
+                if (message.Message.Team == Team.Scripts)
                 {
                     if (player is not null)
                         continue;

--- a/RLBotCS/Server/ServerMessage/SendMatchComm.cs
+++ b/RLBotCS/Server/ServerMessage/SendMatchComm.cs
@@ -3,7 +3,7 @@ using rlbot.flat;
 
 namespace RLBotCS.Server.ServerMessage;
 
-record SendMatchComm(int ClientId, int SpawnId, MatchCommT MatchComm) : IServerMessage
+record SendMatchComm(int ClientId, MatchCommT MatchComm) : IServerMessage
 {
     public ServerAction Execute(ServerContext context)
     {

--- a/RLBotCS/Team.cs
+++ b/RLBotCS/Team.cs
@@ -1,0 +1,10 @@
+namespace rlbot.flat;
+
+// Not an enum since it that would create a lot of conversion back of forth to uint
+public static class Team
+{
+    public static uint Blue = 0;
+    public static uint Orange = 1;
+    public static uint Scripts = 2;
+    public static uint Other = 3; // E.g. match managers
+}


### PR DESCRIPTION
Match comms from a match manager will have index=0 and team=3. They cannot (currently) be displayed in quick chat.