### PR TITLE
Fix spawn ids mismatch

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.6.2");
+    Console.WriteLine("RLBotServer v5.beta.6.3");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/ManagerTools/ConfigValidator.cs
+++ b/RLBotCS/ManagerTools/ConfigValidator.cs
@@ -156,6 +156,8 @@ public static class ConfigValidator
                     valid = false;
                     break;
             }
+
+            player.SpawnId = player.Variety.Type == PlayerClass.Human ? 0 : $"{player.AgentId}/{player.Team}/{i}".GetHashCode();
         }
 
         if (humanCount > 1)
@@ -200,6 +202,7 @@ public static class ConfigValidator
             script.Name ??= "";
             script.RunCommand ??= "";
             script.RootDir ??= "";
+            script.SpawnId = $"{script.AgentId}/{Team.Scripts}/{i}".GetHashCode();
         }
 
         return valid;

--- a/RLBotCS/ManagerTools/MatchStarter.cs
+++ b/RLBotCS/ManagerTools/MatchStarter.cs
@@ -147,12 +147,6 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
             {
                 _hivemindNameMap[playerConfig.Name] = playerName;
             }
-
-            if (playerConfig.SpawnId == 0)
-            {
-                playerConfig.SpawnId =
-                    $"${playerConfig.AgentId}/${playerConfig.Team}/${i}".GetHashCode();
-            }
         }
 
         Dictionary<string, int> scriptNames = [];
@@ -170,9 +164,6 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
                 scriptNames[scriptName] = 0;
                 scriptConfig.Name = scriptName;
             }
-
-            if (scriptConfig.SpawnId == 0)
-                scriptConfig.SpawnId = scriptConfig.AgentId.GetHashCode();
         }
     }
 


### PR DESCRIPTION
- We now set spawn ids during match config validation (instead of in MatchStarter)
- We now override user-specified spawn ids (given us complete control over spawn ids)

This ensures that the spawn id in the match config sent to players, in the agent reservation, and in the game packet all match up.