### PR TITLE
Make sure players are spawned before distributing packets

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.6.4");
+    Console.WriteLine("RLBotServer v5.beta.6.5");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -76,7 +76,7 @@ class BridgeHandler(
                     _context.PerfMonitor.AddRLBotSample(deltaTime);
 
                 ConsiderDistributingPacket(_context, timeAdvanced);
-                
+
                 _context.MatchStarter.SetCurrentMatchPhase(
                     _context.GameState.MatchPhase,
                     _context.GetPlayerSpawner()
@@ -181,20 +181,29 @@ class BridgeHandler(
     private static void ConsiderDistributingPacket(BridgeContext context, bool timeAdvanced)
     {
         var config = context.MatchConfig;
-        if (config == null) return;
+        if (config == null)
+            return;
 
         // While game is paused (or similar), we distribute less often
-        bool due = context is
-        {
-            ticksSkipped: > MAX_TICK_SKIP,
-            GameState.MatchPhase: MatchPhase.Replay or MatchPhase.Paused or MatchPhase.Ended or MatchPhase.Inactive
-        };
-        if (!timeAdvanced && !due) return;
-        
+        bool due =
+            context
+                is {
+                    ticksSkipped: > MAX_TICK_SKIP,
+                    GameState.MatchPhase: MatchPhase.Replay
+                        or MatchPhase.Paused
+                        or MatchPhase.Ended
+                        or MatchPhase.Inactive
+                };
+        if (!timeAdvanced && !due)
+            return;
+
         // We only distribute the packet if it has all players from the match config,
         // - unless the match is already ongoing, then only the bot players are required (humans may leave).
-        bool inactive = context.GameState.MatchPhase is MatchPhase.Inactive or MatchPhase.Ended;
-        int botCount = config.PlayerConfigurations.Count(p => p.Variety.Type != PlayerClass.Human);
+        bool inactive =
+            context.GameState.MatchPhase is MatchPhase.Inactive or MatchPhase.Ended;
+        int botCount = config.PlayerConfigurations.Count(p =>
+            p.Variety.Type != PlayerClass.Human
+        );
         int requiredPlayers = inactive ? config.PlayerConfigurations.Count : botCount;
         // Assumption: Bots are always the lower indexes
         for (uint i = 0; i < requiredPlayers; i++)
@@ -204,7 +213,7 @@ class BridgeHandler(
                 return;
             }
         }
-        
+
         var packet = context.GameState.ToFlatBuffers();
         context.Writer.TryWrite(new DistributeGamePacket(packet));
     }

--- a/RLBotCS/Server/ServerMessage/DistributeGamePacket.cs
+++ b/RLBotCS/Server/ServerMessage/DistributeGamePacket.cs
@@ -3,7 +3,7 @@ using RLBotCS.ManagerTools;
 
 namespace RLBotCS.Server.ServerMessage;
 
-record DistributeGamePacket(GamePacketT? Packet) : IServerMessage
+record DistributeGamePacket(GamePacketT Packet) : IServerMessage
 {
     private static void DistributeBallPrediction(ServerContext context, GamePacketT packet)
     {
@@ -50,11 +50,8 @@ record DistributeGamePacket(GamePacketT? Packet) : IServerMessage
 
     public ServerAction Execute(ServerContext context)
     {
-        if (Packet is { } packet)
-        {
-            DistributeBallPrediction(context, packet);
-            DistributeState(context, packet);
-        }
+        DistributeBallPrediction(context, Packet);
+        DistributeState(context, Packet);
 
         return ServerAction.Continue;
     }


### PR DESCRIPTION
We should only distribute the packet if it has all players from the match config - unless the match is already ongoing, then only the bot players are required (humans may leave).

Resolves #101.