### PR TITLE
Don't use WMI

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.6.8");
+    Console.WriteLine("RLBotServer v5.beta.6.9");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -201,10 +201,11 @@ public class ConfigParser
             ""
         );
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return runCommandWindows;
-
+#if WINDOWS
+        return runCommandWindows;
+#else
         return GetValue(runnableSettings, Fields.AgentRunCommandLinux, runCommandWindows);
+#endif
     }
 
     private ScriptConfigurationT LoadScriptConfig(string scriptConfigPath)

--- a/RLBotCS/ManagerTools/LaunchManager.cs
+++ b/RLBotCS/ManagerTools/LaunchManager.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
-using WmiLight;
 
 namespace RLBotCS.ManagerTools;
 
@@ -73,14 +72,21 @@ static class LaunchManager
 
     private static string GetProcessArgs(Process process)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return process.StartInfo.Arguments;
+#if WINDOWS
+        int err = ProcessCommandLine.Retrieve(process, out string commandLine);
 
-        using WmiConnection con = new WmiConnection();
-        WmiQuery objects = con.CreateQuery(
-            $"SELECT CommandLine FROM Win32_Process WHERE ProcessId = {process.Id}"
+        if (err == 0)
+            return commandLine;
+
+        Logger.LogError(
+            $"Failed to retrieve command line arguments for process {0}: {1}",
+            process.ProcessName,
+            ProcessCommandLine.ErrorToString(err)
         );
-        return objects.SingleOrDefault()?["CommandLine"]?.ToString() ?? "";
+        return "";
+#else
+        return process.StartInfo.Arguments;
+#endif
     }
 
     private static string[] GetIdealArgs(int gamePort) =>
@@ -109,20 +115,13 @@ static class LaunchManager
     {
         Process process = new();
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            process.StartInfo.FileName = "cmd.exe";
-            process.StartInfo.Arguments = $"/c {command}";
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            process.StartInfo.FileName = "/bin/sh";
-            process.StartInfo.Arguments = $"-c \"{command}\"";
-        }
-        else
-            throw new PlatformNotSupportedException(
-                "RLBot is not supported on non-Windows/Linux platforms"
-            );
+#if WINDOWS
+        process.StartInfo.FileName = "cmd.exe";
+        process.StartInfo.Arguments = $"/c {command}";
+#else
+        process.StartInfo.FileName = "/bin/sh";
+        process.StartInfo.Arguments = $"-c \"{command}\"";
+#endif
 
         return process;
     }
@@ -139,24 +138,16 @@ static class LaunchManager
     {
         Process heroic;
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            heroic = RunCommandInShell(
-                "xdg-open 'heroic://launch?appName=Sugar&runner=legendary&arg=-rlbot&arg=RLBot_ControllerURL%3D127.0.0.1%3A23233&arg=RLBot_PacketSendRate%3D240&arg=-nomovie'"
-            );
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            heroic = RunCommandInShell(
-                "start \"\" \"heroic://launch?appName=Sugar&runner=legendary&arg=-rlbot&arg=RLBot_ControllerURL%3D127.0.0.1%3A23233&arg=RLBot_PacketSendRate%3D240&arg=-nomovie\""
-            );
-        }
-        else
-        {
-            throw new PlatformNotSupportedException(
-                "RLBot is not supported on non-Windows/Linux platforms"
-            );
-        }
+#if WINDOWS
+        heroic = RunCommandInShell(
+            "start \"\" \"heroic://launch?appName=Sugar&runner=legendary&arg=-rlbot&arg=RLBot_ControllerURL%3D127.0.0.1%3A23233&arg=RLBot_PacketSendRate%3D240&arg=-nomovie\""
+        );
+#else
+        heroic = RunCommandInShell(
+            "xdg-open 'heroic://launch?appName=Sugar&runner=legendary&arg=-rlbot&arg=RLBot_ControllerURL%3D127.0.0.1%3A23233&arg=RLBot_PacketSendRate%3D240&arg=-nomovie'"
+        );
+#endif
+
         heroic.Start();
     }
 
@@ -258,147 +249,140 @@ static class LaunchManager
         int gamePort
     )
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            switch (launcherPref)
-            {
-                case rlbot.flat.Launcher.Steam:
-                    string steamPath = GetWindowsSteamPath();
-                    Process steam = new();
-                    steam.StartInfo.FileName = steamPath;
-                    steam.StartInfo.Arguments =
-                        $"-applaunch {SteamGameId} "
-                        + string.Join(" ", GetIdealArgs(gamePort));
+#if WINDOWS
+        switch (launcherPref)
+        {
+            case rlbot.flat.Launcher.Steam:
+                string steamPath = GetWindowsSteamPath();
+                Process steam = new();
+                steam.StartInfo.FileName = steamPath;
+                steam.StartInfo.Arguments =
+                    $"-applaunch {SteamGameId} " + string.Join(" ", GetIdealArgs(gamePort));
 
-                    Logger.LogInformation(
-                        $"Starting Rocket League with args {steamPath} {steam.StartInfo.Arguments}"
-                    );
-                    steam.Start();
-                    break;
-                case rlbot.flat.Launcher.Epic:
-                    bool nonRLBotGameRunning = IsRocketLeagueRunning();
+                Logger.LogInformation(
+                    $"Starting Rocket League with args {steamPath} {steam.StartInfo.Arguments}"
+                );
+                steam.Start();
+                break;
+            case rlbot.flat.Launcher.Epic:
+                bool nonRLBotGameRunning = IsRocketLeagueRunning();
 
-                    // we don't need to start the game because there's another instance of non-rlbot rocket league open
-                    if (!nonRLBotGameRunning)
-                    {
-                        // we need a hack to launch the game properly
-                        // start the game
-                        Process launcher = new();
-                        launcher.StartInfo.FileName = "cmd.exe";
-                        launcher.StartInfo.Arguments =
-                            "/c start \"\" \"com.epicgames.launcher://apps/9773aa1aa54f4f7b80e44bef04986cea%3A530145df28a24424923f5828cc9031a1%3ASugar?action=launch&silent=true\"";
-                        launcher.Start();
+                // we don't need to start the game because there's another instance of non-rlbot rocket league open
+                if (!nonRLBotGameRunning)
+                {
+                    // we need a hack to launch the game properly
+                    // start the game
+                    Process launcher = new();
+                    launcher.StartInfo.FileName = "cmd.exe";
+                    launcher.StartInfo.Arguments =
+                        "/c start \"\" \"com.epicgames.launcher://apps/9773aa1aa54f4f7b80e44bef04986cea%3A530145df28a24424923f5828cc9031a1%3ASugar?action=launch&silent=true\"";
+                    launcher.Start();
 
-                        // wait for it to start
-                        Thread.Sleep(1000);
-                    }
+                    // wait for it to start
+                    Thread.Sleep(1000);
+                }
 
-                    Console.WriteLine("Waiting for Rocket League path details...");
-                    string? args = null;
+                Logger.LogInformation("Finding Rocket League...");
+                string? args = null;
 
-                    // get the game path & login args, the quickly kill the game
-                    // todo: add max number of retries
-                    while (args is null)
-                    {
-                        // don't kill the game if it was already running, and not for RLBot
-                        args = GetGameArgs(!nonRLBotGameRunning);
-                        Thread.Sleep(1000);
-                    }
+                // get the game path & login args, the quickly kill the game
+                // todo: add max number of retries
+                while (args is null)
+                {
+                    // don't kill the game if it was already running, and not for RLBot
+                    args = GetGameArgs(!nonRLBotGameRunning);
+                    Thread.Sleep(1000);
+                }
 
-                    if (args is null)
-                        throw new Exception("Failed to get Rocket League args");
+                if (args is null)
+                    throw new Exception("Failed to get Rocket League args");
 
-                    string directGamePath = ParseCommand(args)[0];
-                    Logger.LogInformation($"Found Rocket League at \"{directGamePath}\"");
+                string directGamePath = ParseCommand(args)[0];
+                Logger.LogInformation($"Found Rocket League at \"{directGamePath}\"");
 
-                    // append RLBot args
-                    args = args.Replace(directGamePath, "");
-                    args = args.Replace("\"\"", "");
-                    string idealArgs = string.Join(" ", GetIdealArgs(gamePort));
-                    // rlbot args need to be first or the game might ignore them :(
-                    string modifiedArgs = $"\"{directGamePath}\" {idealArgs} {args}";
+                // append RLBot args
+                args = args.Replace(directGamePath, "");
+                args = args.Replace("\"\"", "");
+                string idealArgs = string.Join(" ", GetIdealArgs(gamePort));
+                // rlbot args need to be first or the game might ignore them :(
+                string modifiedArgs = $"\"{directGamePath}\" {idealArgs} {args}";
 
-                    // wait for the game to fully close
-                    while (IsRocketLeagueRunning())
-                        Thread.Sleep(500);
+                // wait for the game to fully close
+                while (IsRocketLeagueRunning())
+                    Thread.Sleep(500);
 
-                    // relaunch the game with the new args
-                    Process epicRocketLeague = new();
-                    epicRocketLeague.StartInfo.FileName = "cmd.exe";
-                    epicRocketLeague.StartInfo.Arguments = $"/c \"{modifiedArgs}\"";
+                // relaunch the game with the new args
+                Process epicRocketLeague = new();
+                epicRocketLeague.StartInfo.FileName = "cmd.exe";
+                epicRocketLeague.StartInfo.Arguments = $"/c \"{modifiedArgs}\"";
 
-                    // prevent the game from printing to the console
-                    epicRocketLeague.StartInfo.UseShellExecute = false;
-                    epicRocketLeague.StartInfo.RedirectStandardOutput = true;
-                    epicRocketLeague.StartInfo.RedirectStandardError = true;
-                    epicRocketLeague.Start();
+                // prevent the game from printing to the console
+                epicRocketLeague.StartInfo.UseShellExecute = false;
+                epicRocketLeague.StartInfo.RedirectStandardOutput = true;
+                epicRocketLeague.StartInfo.RedirectStandardError = true;
+                epicRocketLeague.Start();
 
-                    Logger.LogInformation(
-                        $"Starting RocketLeague.exe directly with {idealArgs}"
-                    );
+                Logger.LogInformation($"Starting RocketLeague.exe directly with {idealArgs}");
 
-                    // if we don't read the output, the game will hang
-                    new Thread(() =>
-                    {
-                        epicRocketLeague.StandardOutput.ReadToEnd();
-                    }).Start();
+                // if we don't read the output, the game will hang
+                new Thread(() =>
+                {
+                    epicRocketLeague.StandardOutput.ReadToEnd();
+                }).Start();
 
-                    break;
-                case rlbot.flat.Launcher.Custom:
-                    if (extraArg.ToLower() == "legendary")
-                    {
-                        LaunchGameViaLegendary();
-                        return;
-                    }
-                    else if (extraArg.ToLower() == "heroic")
-                    {
-                        LaunchGameViaHeroic();
-                        return;
-                    }
+                break;
+            case rlbot.flat.Launcher.Custom:
+                if (extraArg.ToLower() == "legendary")
+                {
+                    LaunchGameViaLegendary();
+                    return;
+                }
+                else if (extraArg.ToLower() == "heroic")
+                {
+                    LaunchGameViaHeroic();
+                    return;
+                }
 
-                    throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
-                case rlbot.flat.Launcher.NoLaunch:
-                    break;
-            }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            switch (launcherPref)
-            {
-                case rlbot.flat.Launcher.Steam:
-                    string args = string.Join("%20", GetIdealArgs(gamePort));
-                    Process rocketLeague = new();
-                    rocketLeague.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-                    rocketLeague.StartInfo.FileName = "steam";
-                    rocketLeague.StartInfo.Arguments =
-                        $"steam://rungameid/{SteamGameId}//{args}";
+                throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
+            case rlbot.flat.Launcher.NoLaunch:
+                break;
+        }
+#else
+        switch (launcherPref)
+        {
+            case rlbot.flat.Launcher.Steam:
+                string args = string.Join("%20", GetIdealArgs(gamePort));
+                Process rocketLeague = new();
+                rocketLeague.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                rocketLeague.StartInfo.FileName = "steam";
+                rocketLeague.StartInfo.Arguments = $"steam://rungameid/{SteamGameId}//{args}";
 
-                    Logger.LogInformation(
-                        $"Starting Rocket League via Steam CLI with {rocketLeague.StartInfo.Arguments}"
-                    );
-                    rocketLeague.Start();
-                    break;
-                case rlbot.flat.Launcher.Epic:
-                    throw new NotSupportedException(
-                        "Epic Games Store is not directly supported on Linux."
-                    );
-                case rlbot.flat.Launcher.Custom:
-                    if (extraArg.ToLower() == "legendary")
-                    {
-                        LaunchGameViaLegendary();
-                        return;
-                    }
-                    else if (extraArg.ToLower() == "heroic")
-                    {
-                        LaunchGameViaHeroic();
-                        return;
-                    }
+                Logger.LogInformation(
+                    $"Starting Rocket League via Steam CLI with {rocketLeague.StartInfo.Arguments}"
+                );
+                rocketLeague.Start();
+                break;
+            case rlbot.flat.Launcher.Epic:
+                throw new NotSupportedException(
+                    "Epic Games Store is not directly supported on Linux."
+                );
+            case rlbot.flat.Launcher.Custom:
+                if (extraArg.ToLower() == "legendary")
+                {
+                    LaunchGameViaLegendary();
+                    return;
+                }
+                else if (extraArg.ToLower() == "heroic")
+                {
+                    LaunchGameViaHeroic();
+                    return;
+                }
 
-                    throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
-                case rlbot.flat.Launcher.NoLaunch:
-                    break;
-            }
-        else
-            throw new PlatformNotSupportedException(
-                "RLBot is not supported on non-Windows/Linux platforms"
-            );
+                throw new NotSupportedException($"Unexpected launcher, \"{extraArg}\"");
+            case rlbot.flat.Launcher.NoLaunch:
+                break;
+        }
+#endif
     }
 
     public static bool IsRocketLeagueRunning() =>

--- a/RLBotCS/ManagerTools/LaunchManager.cs
+++ b/RLBotCS/ManagerTools/LaunchManager.cs
@@ -85,7 +85,7 @@ static class LaunchManager
         );
         return "";
 #else
-        return process.StartInfo.Arguments;
+        return File.ReadAllText($"/proc/{process.Id}/cmdline");
 #endif
     }
 
@@ -398,9 +398,6 @@ static class LaunchManager
         {
             if (!candidate.ProcessName.Contains("RocketLeague"))
                 continue;
-
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return true;
 
             var args = GetProcessArgs(candidate);
             if (args.Contains("rlbot"))

--- a/RLBotCS/ManagerTools/LaunchManager.cs
+++ b/RLBotCS/ManagerTools/LaunchManager.cs
@@ -85,6 +85,8 @@ static class LaunchManager
         );
         return "";
 #else
+        // Solution taken from:
+        // https://stackoverflow.com/a/58843225/10930209
         return File.ReadAllText($"/proc/{process.Id}/cmdline");
 #endif
     }

--- a/RLBotCS/ManagerTools/WinProcArgs.cs
+++ b/RLBotCS/ManagerTools/WinProcArgs.cs
@@ -1,0 +1,260 @@
+#if WINDOWS
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+// Solution taken from:
+// https://stackoverflow.com/a/46006415/10930209
+public static class ProcessCommandLine
+{
+    private static class Win32Native
+    {
+        public const uint PROCESS_BASIC_INFORMATION = 0;
+
+        [Flags]
+        public enum OpenProcessDesiredAccessFlags : uint
+        {
+            PROCESS_VM_READ = 0x0010,
+            PROCESS_QUERY_INFORMATION = 0x0400,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ProcessBasicInformation
+        {
+            public IntPtr Reserved1;
+            public IntPtr PebBaseAddress;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+            public IntPtr[] Reserved2;
+            public IntPtr UniqueProcessId;
+            public IntPtr Reserved3;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct UnicodeString
+        {
+            public ushort Length;
+            public ushort MaximumLength;
+            public IntPtr Buffer;
+        }
+
+        // This is not the real struct!
+        // I faked it to get ProcessParameters address.
+        // Actual struct definition:
+        // https://learn.microsoft.com/en-us/windows/win32/api/winternl/ns-winternl-peb
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PEB
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public IntPtr[] Reserved;
+            public IntPtr ProcessParameters;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RtlUserProcessParameters
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] Reserved1;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
+            public IntPtr[] Reserved2;
+            public UnicodeString ImagePathName;
+            public UnicodeString CommandLine;
+        }
+
+        [DllImport("ntdll.dll")]
+        public static extern uint NtQueryInformationProcess(
+            IntPtr ProcessHandle,
+            uint ProcessInformationClass,
+            IntPtr ProcessInformation,
+            uint ProcessInformationLength,
+            out uint ReturnLength
+        );
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr OpenProcess(
+            OpenProcessDesiredAccessFlags dwDesiredAccess,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
+            uint dwProcessId
+        );
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ReadProcessMemory(
+            IntPtr hProcess,
+            IntPtr lpBaseAddress,
+            IntPtr lpBuffer,
+            uint nSize,
+            out uint lpNumberOfBytesRead
+        );
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(IntPtr hObject);
+    }
+
+    private static bool ReadStructFromProcessMemory<TStruct>(
+        IntPtr hProcess,
+        IntPtr lpBaseAddress,
+        out TStruct val
+    )
+    {
+        val = default!;
+        var structSize = Marshal.SizeOf<TStruct>();
+        var mem = Marshal.AllocHGlobal(structSize);
+        try
+        {
+            if (
+                Win32Native.ReadProcessMemory(
+                    hProcess,
+                    lpBaseAddress,
+                    mem,
+                    (uint)structSize,
+                    out var len
+                ) && (len == structSize)
+            )
+            {
+#pragma warning disable IL2091
+                val = Marshal.PtrToStructure<TStruct>(mem)!;
+#pragma warning restore IL2091
+                return true;
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(mem);
+        }
+        return false;
+    }
+
+    public static string ErrorToString(int error) =>
+        new string[]
+        {
+            "Success",
+            "Failed to open process for reading",
+            "Failed to query process information",
+            "PEB address was null",
+            "Failed to read PEB information",
+            "Failed to read process parameters",
+            "Failed to read command line from process",
+        }[Math.Abs(error)];
+
+    public static int Retrieve(Process process, out string commandLine)
+    {
+        int rc = 0;
+        commandLine = null!;
+        var hProcess = Win32Native.OpenProcess(
+            Win32Native.OpenProcessDesiredAccessFlags.PROCESS_QUERY_INFORMATION
+                | Win32Native.OpenProcessDesiredAccessFlags.PROCESS_VM_READ,
+            false,
+            (uint)process.Id
+        );
+        if (hProcess != IntPtr.Zero)
+        {
+            try
+            {
+                var sizePBI = Marshal.SizeOf<Win32Native.ProcessBasicInformation>();
+                var memPBI = Marshal.AllocHGlobal(sizePBI);
+                try
+                {
+                    var ret = Win32Native.NtQueryInformationProcess(
+                        hProcess,
+                        Win32Native.PROCESS_BASIC_INFORMATION,
+                        memPBI,
+                        (uint)sizePBI,
+                        out var len
+                    );
+                    if (0 == ret)
+                    {
+                        var pbiInfo =
+                            Marshal.PtrToStructure<Win32Native.ProcessBasicInformation>(
+                                memPBI
+                            );
+                        if (pbiInfo.PebBaseAddress != IntPtr.Zero)
+                        {
+                            if (
+                                ReadStructFromProcessMemory<Win32Native.PEB>(
+                                    hProcess,
+                                    pbiInfo.PebBaseAddress,
+                                    out var pebInfo
+                                )
+                            )
+                            {
+                                if (
+                                    ReadStructFromProcessMemory<Win32Native.RtlUserProcessParameters>(
+                                        hProcess,
+                                        pebInfo.ProcessParameters,
+                                        out var ruppInfo
+                                    )
+                                )
+                                {
+                                    var clLen = ruppInfo.CommandLine.MaximumLength;
+                                    var memCL = Marshal.AllocHGlobal(clLen);
+                                    try
+                                    {
+                                        if (
+                                            Win32Native.ReadProcessMemory(
+                                                hProcess,
+                                                ruppInfo.CommandLine.Buffer,
+                                                memCL,
+                                                clLen,
+                                                out len
+                                            )
+                                        )
+                                        {
+                                            commandLine = Marshal.PtrToStringUni(memCL)!;
+                                            rc = 0;
+                                        }
+                                        else
+                                        {
+                                            // couldn't read command line buffer
+                                            rc = -6;
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        Marshal.FreeHGlobal(memCL);
+                                    }
+                                }
+                                else
+                                {
+                                    // couldn't read ProcessParameters
+                                    rc = -5;
+                                }
+                            }
+                            else
+                            {
+                                // couldn't read PEB information
+                                rc = -4;
+                            }
+                        }
+                        else
+                        {
+                            // PebBaseAddress is null
+                            rc = -3;
+                        }
+                    }
+                    else
+                    {
+                        // NtQueryInformationProcess failed
+                        rc = -2;
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(memPBI);
+                }
+            }
+            finally
+            {
+                Win32Native.CloseHandle(hProcess);
+            }
+        }
+        else
+        {
+            // couldn't open process for VM read
+            rc = -1;
+        }
+        return rc;
+    }
+}
+#endif

--- a/RLBotCS/RLBotCS.csproj
+++ b/RLBotCS/RLBotCS.csproj
@@ -20,9 +20,12 @@
 
   <ItemGroup>
     <PackageReference Include="Tomlyn" Version="0.18.0" />
-    <PackageReference Include="WmiLight" Version="6.13.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <DefineConstants>WINDOWS</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.FlatBuffers" Version="25.2.10" />


### PR DESCRIPTION
Closes #110 

WMI is unreliable. It has been replaced by a system that loads `kernel32.dll` which should be present on all Windows systems.

Most platform checks are now done at compile time instead of runtime, with the `WINDOWS` constant.

Linux previous always failed when trying to get the args of another process, this PR also fixes and Linux can now read the launch args of any process.

Bumped version to 0.6.9