### PR TITLE
Fix matches preemptively starting

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.6.9");
+    Console.WriteLine("RLBotServer v5.beta.6.10");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -18,7 +18,7 @@ class BridgeHandler(
     MatchStarter matchStarter
 )
 {
-    private ManualResetEvent conditionMet = new ManualResetEvent(false);
+    private ManualResetEvent startReadingInternalMsgs = new ManualResetEvent(false);
 
     private const int MAX_TICK_SKIP = 1;
     private readonly BridgeContext _context = new(writer, reader, messenger, matchStarter);
@@ -28,7 +28,7 @@ class BridgeHandler(
         // if Rocket League is already running,
         // we wait for it to connect to us first
         if (LaunchManager.IsRocketLeagueRunningWithArgs())
-            conditionMet.WaitOne();
+            startReadingInternalMsgs.WaitOne();
 
         _context.Logger.LogDebug("Started reading internal messages");
 
@@ -68,7 +68,7 @@ class BridgeHandler(
                     // Trigger HandleInternalMessages to start processing messages
                     // it will still wait until we're done,
                     // since we have a lock on _context
-                    conditionMet.Set();
+                    startReadingInternalMsgs.Set();
                 }
 
                 // reset the counter that lets us know if we're sending too many bytes

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -23,7 +23,9 @@ class BridgeHandler(
 
     private async Task HandleInternalMessages()
     {
-        bool isFirstTick = true;
+        // Only if Rocket League is running,
+        // we wait for it to talk to us first
+        bool isFirstTick = LaunchManager.IsRocketLeagueRunningWithArgs();
 
         await foreach (IBridgeMessage message in _context.Reader.ReadAllAsync())
         {

--- a/RLBotCS/Server/ServerMessage/StartMatch.cs
+++ b/RLBotCS/Server/ServerMessage/StartMatch.cs
@@ -12,6 +12,7 @@ record StartMatch(MatchConfigurationT MatchConfig) : IServerMessage
         Debug.Assert(ConfigValidator.Validate(MatchConfig));
 
         context.Bridge.TryWrite(new ClearRenders());
+        context.Bridge.TryWrite(new EndMatch());
 
         foreach (var (writer, _) in context.Sessions.Values)
             writer.TryWrite(new SessionMessage.StopMatch(false));


### PR DESCRIPTION
Waits for the game to connect before parsing bridge messages, but only if RL is launched in RLBot mode upon launch.