### PR TITLE
Avoid special semantics for nulled strings in flatbuffers

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -8,7 +8,7 @@ using RLBotCS.Server.ServerMessage;
 
 if (args.Length > 0 && args[0] == "--version")
 {
-    Console.WriteLine("RLBotServer v5.beta.6.11");
+    Console.WriteLine("RLBotServer v5.beta.6.12");
     Environment.Exit(0);
 }
 

--- a/RLBotCS/ManagerTools/ConfigValidator.cs
+++ b/RLBotCS/ManagerTools/ConfigValidator.cs
@@ -114,7 +114,7 @@ public static class ConfigValidator
                     player.AgentId ??= "psyonix/" + skill; // Not that it really matters
 
                     // Apply Psyonix preset loadouts
-                    if (player.Name == null)
+                    if (string.IsNullOrEmpty(player.Name))
                     {
                         (player.Name, var preset) = PsyonixLoadouts.GetNext((int)player.Team);
                         string andPreset = player.Loadout == null ? " and preset" : "";

--- a/RLBotCS/ManagerTools/QuickChat.cs
+++ b/RLBotCS/ManagerTools/QuickChat.cs
@@ -39,7 +39,7 @@ public class QuickChat
 
     public void AddChat(MatchCommT matchComm, string name, float gameTime)
     {
-        if (matchComm.Display == null)
+        if (string.IsNullOrEmpty(matchComm.Display))
             return;
 
         _chats.AddLast((gameTime, name, matchComm));


### PR DESCRIPTION
This fixes all instances of nulled strings behaving differently that I found.

Resolves #120 