### PR TITLE
Custom map support

### DIFF
--- a/RLBotCS/Conversion/FlatToCommand.cs
+++ b/RLBotCS/Conversion/FlatToCommand.cs
@@ -388,17 +388,27 @@ static class FlatToCommand
         return "";
     }
 
-    public static string MakeOpenCommand(MatchConfigurationT matchConfig)
+    public static (string, CustomMap?) MakeOpenCommand(MatchConfigurationT matchConfig)
     {
         var command = "Open ";
+        CustomMap? customMap = null;
 
         // Parse game map
-        // With RLBot v5, GameMap enum is now ignored
-        // You MUST use GameMapUpk instead
         // This is the name of the map file without the extension
         // And can also be used to tell the game to load custom maps
         if (matchConfig.GameMapUpk != "")
-            command += matchConfig.GameMapUpk;
+        {
+            if (CustomMap.IsCustomMap(matchConfig.GameMapUpk))
+            {
+                // load the custom map
+                customMap = new(matchConfig.GameMapUpk);
+                command += CustomMap.RL_MAP_KEY;
+            }
+            else
+            {
+                command += matchConfig.GameMapUpk;
+            }
+        }
         else
         {
             command += "Stadium_P";
@@ -421,7 +431,7 @@ static class FlatToCommand
             command += ",Freeplay";
 
         if (matchConfig.Mutators is not { } mutatorSettings)
-            return command;
+            return (command, customMap);
 
         // Parse mutator settings
         command += GetOption(MapMatchLength(mutatorSettings.MatchLength));
@@ -457,7 +467,7 @@ static class FlatToCommand
         command += GetOption(MapInputRestriction(mutatorSettings.InputRestriction));
         command += GetOption(MapScoringRule(mutatorSettings.ScoringRule));
 
-        return command;
+        return (command, customMap);
     }
 
     public static string MakeGameSpeedCommand(float gameSpeed) =>

--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -10,7 +10,7 @@ using RLBotCS.Server.ServerMessage;
 if (args.Length > 0 && args[0] == "--version")
 {
     Console.WriteLine(
-        $"RLBotServer v5.beta.7.3\n"
+        $"RLBotServer v5.beta.7.4\n"
             + $"Bridge {BridgeVersion.Version}\n"
             + $"@ https://www.rlbot.org & https://github.com/RLBot/core"
     );

--- a/RLBotCS/ManagerTools/CustomMap.cs
+++ b/RLBotCS/ManagerTools/CustomMap.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+
+namespace RLBotCS.ManagerTools;
+
+public class CustomMap
+{
+    private static readonly ILogger Logger = Logging.GetLogger("CustomMap");
+
+    public const string RL_MAP_KEY = "Haunted_TrainStation_P";
+    private const string MAP_SACRAFICE = RL_MAP_KEY + ".upk";
+    private const string TEMP_MAP_NAME = RL_MAP_KEY + "_copy.upk";
+
+    public static bool IsCustomMap(string path)
+    {
+        bool isMapPath = path.EndsWith(".upk") || path.EndsWith(".udk");
+        return isMapPath && File.Exists(path);
+    }
+
+    private static string GetMapsBasePath()
+    {
+        // rocketleague/Binaries/Win64/RocketLeague.exe
+        string? gamePath = LaunchManager.GetRocketLeaguePath();
+        if (gamePath == null)
+        {
+            // throw exception because we shouldn't construct this class before Rocket League has launched
+            throw new InvalidOperationException("Could not find Rocket League executable");
+        }
+
+        // rocketleague/
+        string basePath = Path.GetDirectoryName(
+            Path.GetDirectoryName(Path.GetDirectoryName(gamePath)!)!
+        )!;
+        // rocketleague/TAGame/CookedPCConsole
+        return Path.Combine(basePath, "TAGame", "CookedPCConsole");
+    }
+
+    private string _originalMapPath;
+    private string _tempMapPath;
+
+    public CustomMap(string path)
+    {
+        if (!IsCustomMap(path))
+        {
+            // throw exception because we shouldn't construct this class with an invalid path
+            throw new ArgumentException("Provided path is not a valid custom map");
+        }
+
+        string mapsBasePath = GetMapsBasePath();
+        _originalMapPath = Path.Combine(mapsBasePath, MAP_SACRAFICE);
+        _tempMapPath = Path.Combine(mapsBasePath, TEMP_MAP_NAME);
+
+        Logger.LogInformation($"Custom map detected, loading into {RL_MAP_KEY}");
+
+        // don't overwrite the original map if it already exists
+        if (!File.Exists(_tempMapPath))
+        {
+            // copy the original map to a temporary file so we can restore it later
+            File.Copy(_originalMapPath, _tempMapPath, false);
+        }
+
+        // replace the original map with the custom map
+        File.Copy(path, _originalMapPath, true);
+    }
+
+    public void TryRestoreOriginalMap()
+    {
+        if (!File.Exists(_tempMapPath))
+            return;
+
+        File.Copy(_tempMapPath, _originalMapPath, true);
+        File.Delete(_tempMapPath);
+        Logger.LogInformation($"Restored original map of {RL_MAP_KEY}");
+    }
+
+    ~CustomMap()
+    {
+        // Doing this in the destructor to ensure that the original map is restored,
+        // even if an invalid state occurs elsewhere
+        TryRestoreOriginalMap();
+    }
+}

--- a/RLBotCS/ManagerTools/CustomMap.cs
+++ b/RLBotCS/ManagerTools/CustomMap.cs
@@ -7,7 +7,7 @@ public class CustomMap
     private static readonly ILogger Logger = Logging.GetLogger("CustomMap");
 
     public const string RL_MAP_KEY = "Haunted_TrainStation_P";
-    private const string MAP_SACRAFICE = RL_MAP_KEY + ".upk";
+    private const string MAP_SACRIFICE = RL_MAP_KEY + ".upk";
     private const string TEMP_MAP_NAME = RL_MAP_KEY + "_copy.upk";
 
     public static bool IsCustomMap(string path)
@@ -46,7 +46,7 @@ public class CustomMap
         }
 
         string mapsBasePath = GetMapsBasePath();
-        _originalMapPath = Path.Combine(mapsBasePath, MAP_SACRAFICE);
+        _originalMapPath = Path.Combine(mapsBasePath, MAP_SACRIFICE);
         _tempMapPath = Path.Combine(mapsBasePath, TEMP_MAP_NAME);
 
         Logger.LogInformation($"Custom map detected, loading into {RL_MAP_KEY}");

--- a/RLBotCS/ManagerTools/CustomMap.cs
+++ b/RLBotCS/ManagerTools/CustomMap.cs
@@ -49,7 +49,7 @@ public class CustomMap
         _originalMapPath = Path.Combine(mapsBasePath, MAP_SACRIFICE);
         _tempMapPath = Path.Combine(mapsBasePath, TEMP_MAP_NAME);
 
-        Logger.LogInformation($"Custom map detected, loading into {RL_MAP_KEY}");
+        Logger.LogInformation($"Custom map detected. Temporarily replacing {RL_MAP_KEY}");
 
         // don't overwrite the original map if it already exists
         if (!File.Exists(_tempMapPath))

--- a/RLBotCS/ManagerTools/MatchStarter.cs
+++ b/RLBotCS/ManagerTools/MatchStarter.cs
@@ -23,6 +23,12 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
 
     private Dictionary<string, string> _hivemindNameMap = new();
 
+    /// <summary>
+    /// If this value is not null,
+    /// then a custom map is being loaded.
+    /// </summary>
+    private CustomMap? _customMap;
+
     public readonly AgentMapping AgentMapping = new();
 
     public bool HasSpawnedCars { get; private set; }
@@ -107,6 +113,11 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
     {
         Logger.LogInformation("Got map info for " + mapName);
         HasSpawnedMap = true;
+        if (_customMap is not null)
+        {
+            _customMap.TryRestoreOriginalMap();
+            _customMap = null;
+        }
 
         if (_deferredMatchConfig is { } matchConfig)
         {
@@ -246,7 +257,9 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
             _matchConfig = null;
             _deferredMatchConfig = matchConfig;
 
-            var cmd = spawner.SpawnMap(matchConfig);
+            var (cmd, customMap) = spawner.SpawnMap(matchConfig);
+            _customMap = customMap;
+
             Logger.LogInformation($"Loading map with command: {cmd}");
         }
         else

--- a/RLBotCS/ManagerTools/PlayerSpawner.cs
+++ b/RLBotCS/ManagerTools/PlayerSpawner.cs
@@ -113,12 +113,14 @@ public readonly ref struct PlayerSpawner(
         }
     }
 
-    public string SpawnMap(MatchConfigurationT matchConfig)
+    public (string, CustomMap?) SpawnMap(MatchConfigurationT matchConfig)
     {
-        string loadMapCommand = FlatToCommand.MakeOpenCommand(matchConfig);
+        (string loadMapCommand, CustomMap? customMap) = FlatToCommand.MakeOpenCommand(
+            matchConfig
+        );
         spawnCommandQueue.AddConsoleCommand(loadMapCommand);
         spawnCommandQueue.Flush();
-        return loadMapCommand;
+        return (loadMapCommand, customMap);
     }
 
     public void Flush()


### PR DESCRIPTION
Closes #112 

![image](https://github.com/user-attachments/assets/c7bc7fd4-d31e-41d4-b689-8f23b87a1646)

When a custom map is detected, `Haunted_TrainStation_P.upk` gets copied and the custom map gets moved to be `Haunted_TrainStation_P.upk`. Once the custom map gets loaded, the original `Haunted_TrainStation_P.upk` gets immediately restored.

Requirements for a custom map to be detected:
- `game_map_upk` must end in `.upk` or `.udk`
- `game_map_upk` must be a file path that exists

If either of these are not true, we pass `game_map_upk` directly to Rocket League just like previously.

The path to `CookedPCConsole` is found by looking for a running `RocketLeague.exe` process and starting at the path that was used to launch the executable.