### PR TITLE
Force-enable colors for cmd.exe

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -7,19 +7,19 @@ using RLBotCS.Server;
 using RLBotCS.Server.BridgeMessage;
 using RLBotCS.Server.ServerMessage;
 
-#if WINDOWS
-WinTermColor.EnableVirtualTerminal();
-#endif
-
 if (args.Length > 0 && args[0] == "--version")
 {
     Console.WriteLine(
-        $"{Logging.Yellow}RLBotServer {Logging.Green}v5.beta.7.5\n"
-            + $"{Logging.Yellow}Bridge {Logging.Green}{BridgeVersion.Version}{Logging.Reset}\n"
-            + $"@ {Logging.LightBlue}https://www.rlbot.org{Logging.Reset} & {Logging.LightBlue}https://github.com/RLBot/core{Logging.Reset}"
+        "RLBotServer v5.beta.7.5\n"
+            + $"Bridge {BridgeVersion.Version}\n"
+            + "@ https://www.rlbot.org & https://github.com/RLBot/core"
     );
     Environment.Exit(0);
 }
+
+#if WINDOWS
+WinTermColor.EnableVirtualTerminal();
+#endif
 
 var logger = Logging.GetLogger("Main");
 

--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -7,12 +7,16 @@ using RLBotCS.Server;
 using RLBotCS.Server.BridgeMessage;
 using RLBotCS.Server.ServerMessage;
 
+#if WINDOWS
+WinTermColor.EnableVirtualTerminal();
+#endif
+
 if (args.Length > 0 && args[0] == "--version")
 {
     Console.WriteLine(
-        $"RLBotServer v5.beta.7.4\n"
-            + $"Bridge {BridgeVersion.Version}\n"
-            + $"@ https://www.rlbot.org & https://github.com/RLBot/core"
+        $"{Logging.Yellow}RLBotServer {Logging.Green}v5.beta.7.5\n"
+            + $"{Logging.Yellow}Bridge {Logging.Green}{BridgeVersion.Version}{Logging.Reset}\n"
+            + $"@ {Logging.LightBlue}https://www.rlbot.org{Logging.Reset} & {Logging.LightBlue}https://github.com/RLBot/core{Logging.Reset}"
     );
     Environment.Exit(0);
 }

--- a/RLBotCS/ManagerTools/Logging.cs
+++ b/RLBotCS/ManagerTools/Logging.cs
@@ -5,13 +5,13 @@ namespace RLBotCS.ManagerTools;
 
 public class Logging : ILogger
 {
-    public const string Grey = "\x1b[38;20m";
-    public const string LightBlue = "\x1b[94;20m";
-    public const string Yellow = "\x1b[33;20m";
-    public const string Green = "\x1b[32;20m";
-    public const string Red = "\x1b[31;20m";
-    public const string BoldRed = "\x1b[31;1m";
-    public const string Reset = "\x1b[0m";
+    private const string Grey = "\x1b[38;20m";
+    private const string LightBlue = "\x1b[94;20m";
+    private const string Yellow = "\x1b[33;20m";
+    private const string Green = "\x1b[32;20m";
+    private const string Red = "\x1b[31;20m";
+    private const string BoldRed = "\x1b[31;1m";
+    private const string Reset = "\x1b[0m";
 
     private static readonly LogLevel LoggingLevel = Environment.GetEnvironmentVariable(
         "RLBOT_LOG_LEVEL"

--- a/RLBotCS/ManagerTools/Logging.cs
+++ b/RLBotCS/ManagerTools/Logging.cs
@@ -5,13 +5,13 @@ namespace RLBotCS.ManagerTools;
 
 public class Logging : ILogger
 {
-    private const string Grey = "\x1b[38;20m";
-    private const string LightBlue = "\x1b[94;20m";
-    private const string Yellow = "\x1b[33;20m";
-    private const string Green = "\x1b[32;20m";
-    private const string Red = "\x1b[31;20m";
-    private const string BoldRen = "\x1b[31;1m";
-    private const string Reset = "\x1b[0m";
+    public const string Grey = "\x1b[38;20m";
+    public const string LightBlue = "\x1b[94;20m";
+    public const string Yellow = "\x1b[33;20m";
+    public const string Green = "\x1b[32;20m";
+    public const string Red = "\x1b[31;20m";
+    public const string BoldRed = "\x1b[31;1m";
+    public const string Reset = "\x1b[0m";
 
     private static readonly LogLevel LoggingLevel = Environment.GetEnvironmentVariable(
         "RLBOT_LOG_LEVEL"
@@ -80,7 +80,7 @@ public class Logging : ILogger
             LogLevel.Information => new[] { Grey, LightBlue, Grey, LightBlue },
             LogLevel.Warning => new[] { Yellow, Yellow, Yellow, Yellow },
             LogLevel.Error => new[] { Red, Red, Red, Red },
-            LogLevel.Critical => new[] { Red, BoldRen, Red, BoldRen },
+            LogLevel.Critical => new[] { Red, BoldRed, Red, BoldRed },
             _ => new[] { Grey, Grey, Grey, Grey },
         };
 

--- a/RLBotCS/ManagerTools/WinTermColor.cs
+++ b/RLBotCS/ManagerTools/WinTermColor.cs
@@ -1,0 +1,37 @@
+#if WINDOWS
+using System.Runtime.InteropServices;
+
+public class WinTermColor
+{
+    const int STD_OUTPUT_HANDLE = -11;
+    const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern IntPtr GetStdHandle(int nStdHandle);
+
+    [DllImport("kernel32.dll")]
+    static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+    [DllImport("kernel32.dll")]
+    static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+    public static void EnableVirtualTerminal()
+    {
+        var handle = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (!GetConsoleMode(handle, out uint mode))
+        {
+            // Don't use the logger here because we couldn't enable colors
+            Console.WriteLine("Failed to get console mode.");
+            return;
+        }
+
+        mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+        if (!SetConsoleMode(handle, mode))
+        {
+            // Don't use logger for the same reason
+            Console.WriteLine("Failed to set console mode.");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Similar to how in Python we do `os.system("color")` on Windows to enable ascii colors, this does the same for Windows but in C#.

I also colored the version output. I can remove it if deemed unwanted.

![image](https://github.com/user-attachments/assets/7dcad9d0-5e8e-4a66-b078-0b542f72a886)
