### PR TITLE
De-duplicate Psyonix bot names

### DIFF
--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -167,7 +167,7 @@ public class ConfigParser
                     return res;
                 throw new InvalidCastException(
                     $"{_context.ToStringWithEnd(key)} has invalid value \"{raw}\". "
-                        + $"Find valid values on https:/wiki.rlbot.org."
+                        + $"Find valid values on https://wiki.rlbot.org."
                 );
             }
             else
@@ -199,7 +199,7 @@ public class ConfigParser
                     default:
                         throw new InvalidCastException(
                             $"{_context.ToStringWithEnd(Fields.AgentType)} has invalid value \"{raw}\". "
-                                + $"Find valid values on https:/wiki.rlbot.org."
+                                + $"Find valid values on https://wiki.rlbot.org."
                         );
                 }
             }

--- a/RLBotCS/ManagerTools/MatchStarter.cs
+++ b/RLBotCS/ManagerTools/MatchStarter.cs
@@ -135,7 +135,7 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
         if (nameCounts.TryGetValue(name, out int count))
         {
             nameCounts[name] = ++count;
-            name += $" ({count})";
+            name += $" ({count + 1})";
         }
         else
         {

--- a/RLBotCS/ManagerTools/MatchStarter.cs
+++ b/RLBotCS/ManagerTools/MatchStarter.cs
@@ -130,6 +130,21 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
         }
     }
 
+    private static string DedupName(string name, Dictionary<string, int> nameCounts)
+    {
+        if (nameCounts.TryGetValue(name, out int count))
+        {
+            nameCounts[name] = ++count;
+            name += $" ({count})";
+        }
+        else
+        {
+            nameCounts[name] = 0;
+        }
+
+        return name;
+    }
+
     private void PreprocessMatch(MatchConfigurationT matchConfig)
     {
         Dictionary<string, int> playerNames = [];
@@ -138,43 +153,28 @@ class MatchStarter(int gamePort, int rlbotSocketsPort)
         foreach (var player in matchConfig.PlayerConfigurations)
         {
             // De-duplicating similar names. Overwrites original value.
-
-            if (player.Variety.Value is CustomBotT config)
+            switch (player.Variety.Value)
             {
-                string playerName = config.Name ?? "";
-                if (playerNames.TryGetValue(playerName, out int value))
-                {
-                    playerNames[playerName] = ++value;
-                    config.Name = playerName + $" ({value + 1})";
-                }
-                else
-                {
-                    playerNames[playerName] = 0;
-                    config.Name = playerName;
-                }
+                case CustomBotT config:
+                    string playerName = config.Name ?? "";
+                    config.Name = DedupName(playerName, playerNames);
 
-                if (config.Hivemind)
-                {
-                    _hivemindNameMap[config.Name] = playerName;
-                }
+                    if (config.Hivemind)
+                    {
+                        _hivemindNameMap[config.Name] = playerName;
+                    }
+                    break;
+                case PsyonixBotT config:
+                    config.Name = DedupName(config.Name ?? "", playerNames);
+                    break;
             }
         }
 
         Dictionary<string, int> scriptNames = [];
-        foreach (var scriptConfig in matchConfig.ScriptConfigurations)
+        foreach (var script in matchConfig.ScriptConfigurations)
         {
             // De-duplicating similar names. Overwrites original value.
-            string scriptName = scriptConfig.Name ?? "";
-            if (scriptNames.TryGetValue(scriptName, out int value))
-            {
-                scriptNames[scriptName] = ++value;
-                scriptConfig.Name = scriptName + $" ({value})";
-            }
-            else
-            {
-                scriptNames[scriptName] = 0;
-                scriptConfig.Name = scriptName;
-            }
+            script.Name = DedupName(script.Name ?? "", scriptNames);
         }
     }
 


### PR DESCRIPTION
2 Psyonix Beginner with custom names vs 2 Psyonix Allstar with custom names, post-patch:

<img width="338" height="402" alt="image" src="https://github.com/user-attachments/assets/d56387bf-c2e7-407a-916c-a63773fcdb22" />

Fixes #143