### PR TITLE
Improve perfmonitor

### DIFF
--- a/RLBotCS/ManagerTools/CircularBuffer.cs
+++ b/RLBotCS/ManagerTools/CircularBuffer.cs
@@ -2,11 +2,11 @@ namespace RLBotCS.ManagerTools;
 
 public class CircularBuffer<T>
 {
-    private int _startIndex;
-    private int _currentIndex;
+    private int _size = 0;
+    private int _currentIndex = 0;
     private readonly T[] _buffer;
 
-    public int Count => (_currentIndex - _startIndex + _buffer.Length) % _buffer.Length;
+    public int Count => _buffer.Length;
 
     public CircularBuffer(int capacity)
     {
@@ -16,16 +16,13 @@ public class CircularBuffer<T>
     public void AddLast(T item)
     {
         _buffer[_currentIndex] = item;
-
-        // continuously overwrite the oldest item once full
+        _size = Math.Max(_currentIndex + 1, _size);
         _currentIndex = (_currentIndex + 1) % _buffer.Length;
-        if (_currentIndex == _startIndex)
-            _startIndex = (_startIndex + 1) % _buffer.Length;
     }
 
     public IEnumerable<T> Iter()
     {
-        for (int i = _startIndex; i != _currentIndex; i = (i + 1) % _buffer.Length)
-            yield return _buffer[i];
+        for (int i = 0; i < Math.Min(_buffer.Length, _size); i++)
+            yield return _buffer[(i + _currentIndex) % _buffer.Length];
     }
 }

--- a/RLBotCS/ManagerTools/PerfMonitor.cs
+++ b/RLBotCS/ManagerTools/PerfMonitor.cs
@@ -1,6 +1,8 @@
 using Bridge.State;
 using RLBot.Flat;
 
+using Deltas = (float GameTimeDelta, float ArrivalDelta);
+
 namespace RLBotCS.ManagerTools;
 
 public class PerfMonitor
@@ -25,13 +27,13 @@ public class PerfMonitor
         B = 0,
     };
 
-    private readonly CircularBuffer<float> _rlbotSamples = new(_maxSamples);
+    private readonly CircularBuffer<Deltas> _rlbotSamples = new(_maxSamples);
     private readonly SortedDictionary<string, CircularBuffer<bool>> _samples = new();
     private float time = 0;
 
-    public void AddRLBotSample(float timeDiff)
+    public void AddRLBotSample(Deltas deltas)
     {
-        _rlbotSamples.AddLast(timeDiff);
+        _rlbotSamples.AddLast(deltas);
     }
 
     public void AddSample(string name, bool gotInput)
@@ -49,6 +51,19 @@ public class PerfMonitor
         _samples.Remove(name);
     }
 
+    public static float GetPercentile(IEnumerable<float> data, float p)
+    {
+        var sorted = data.OrderBy(x => x).ToList();
+        int n = sorted.Count;
+        if (n == 0) return default;
+
+        double rank = p * (n - 1);
+        int lower = (int)Math.Floor(rank);
+        int upper = (int)Math.Ceiling(rank);
+
+        return (float)(sorted[lower] + (rank - lower) * (sorted[upper] - sorted[lower]));
+    }
+
     public void RenderSummary(Rendering rendering, GameState gameState, float deltaTime)
     {
         time += deltaTime;
@@ -56,11 +71,28 @@ public class PerfMonitor
             return;
         time = 0;
 
-        float averageTimeDiff = _rlbotSamples.Count > 0 ? _rlbotSamples.Iter().Average() : 1;
-        float timeDiffPercentage = 1 / (120f * averageTimeDiff);
 
-        string message = $"RLBot: {timeDiffPercentage * 100:0.0}%";
-        bool shouldRender = timeDiffPercentage < 0.9999 || timeDiffPercentage > 1.0001;
+        var arrivalDeltas = _rlbotSamples.Iter().Select(t => t.ArrivalDelta);
+        var gameTimeDeltas = _rlbotSamples.Iter().Select(t => t.GameTimeDelta);
+
+        float averageTickDelta = gameTimeDeltas.Sum() / _maxSamples;
+        float averageTickRate = 1f / averageTickDelta;
+
+        // Find deltas larger than expected at 60hz, allowing 10% margin
+        float misses60 = arrivalDeltas
+            .Count(d =>
+                (d - (1f / 60f)) > (0.1f / 60f));
+
+        // Find deltas larger than expected at 120hz, allowing 10% margin
+        float misses120 = arrivalDeltas
+            .Count(d =>
+                (d - (1f / 120f)) > (0.1f / 120f));
+
+        string message = $"""
+        RLBot @ {averageTickRate:0}hz {(1f - misses60 / 120f) * 100f:0}%|{(1f - misses120 / 120f) * 100f:0}%
+         p95 {GetPercentile(arrivalDeltas, 0.95f) * 1000f:0.0}ms p99 {GetPercentile(arrivalDeltas, 0.99f) * 1000f:0.0}ms
+        """;
+        bool shouldRender = misses120 > 1;
 
         foreach (var (name, samples) in _samples)
         {

--- a/RLBotCS/ManagerTools/PerfMonitor.cs
+++ b/RLBotCS/ManagerTools/PerfMonitor.cs
@@ -1,6 +1,5 @@
 using Bridge.State;
 using RLBot.Flat;
-
 using Deltas = (float GameTimeDelta, float ArrivalDelta);
 
 namespace RLBotCS.ManagerTools;
@@ -55,7 +54,8 @@ public class PerfMonitor
     {
         var sorted = data.OrderBy(x => x).ToList();
         int n = sorted.Count;
-        if (n == 0) return default;
+        if (n == 0)
+            return default;
 
         double rank = p * (n - 1);
         int lower = (int)Math.Floor(rank);
@@ -71,7 +71,6 @@ public class PerfMonitor
             return;
         time = 0;
 
-
         var arrivalDeltas = _rlbotSamples.Iter().Select(t => t.ArrivalDelta);
         var gameTimeDeltas = _rlbotSamples.Iter().Select(t => t.GameTimeDelta);
 
@@ -79,19 +78,20 @@ public class PerfMonitor
         float averageTickRate = 1f / averageTickDelta;
 
         // Find deltas larger than expected at 60hz, allowing 10% margin
-        float misses60 = arrivalDeltas
-            .Count(d =>
-                (d - (1f / 60f)) > (0.1f / 60f));
+        float misses60 = arrivalDeltas.Count(d => (d - (1f / 60f)) > (0.1f / 60f));
 
         // Find deltas larger than expected at 120hz, allowing 10% margin
-        float misses120 = arrivalDeltas
-            .Count(d =>
-                (d - (1f / 120f)) > (0.1f / 120f));
+        float misses120 = arrivalDeltas.Count(d => (d - (1f / 120f)) > (0.1f / 120f));
 
         string message = $"""
-        RLBot @ {averageTickRate:0}hz {(1f - misses60 / 120f) * 100f:0}%|{(1f - misses120 / 120f) * 100f:0}%
-         p95 {GetPercentile(arrivalDeltas, 0.95f) * 1000f:0.0}ms p99 {GetPercentile(arrivalDeltas, 0.99f) * 1000f:0.0}ms
-        """;
+            RLBot @ {averageTickRate:0}hz {(1f - misses60 / 120f) * 100f:0}%|{(
+                1f - misses120 / 120f
+            ) * 100f:0}%
+             p95 {GetPercentile(arrivalDeltas, 0.95f) * 1000f:0.0}ms p99 {GetPercentile(
+                arrivalDeltas,
+                0.99f
+            ) * 1000f:0.0}ms
+            """;
         bool shouldRender = misses120 > 1;
 
         foreach (var (name, samples) in _samples)

--- a/RLBotCS/ManagerTools/PerfMonitor.cs
+++ b/RLBotCS/ManagerTools/PerfMonitor.cs
@@ -77,22 +77,29 @@ public class PerfMonitor
         float averageTickDelta = gameTimeDeltas.Sum() / _maxSamples;
         float averageTickRate = 1f / averageTickDelta;
 
-        // Find deltas larger than expected at 60hz, allowing 10% margin
+        // Find deltas larger than expected at averageTickRate, allowing 10% margin
+        float missesAdaptive = arrivalDeltas.Count(d =>
+            (d - (1f / averageTickRate)) > (0.1f / averageTickRate)
+        );
+
+        // Find deltas larger than expected at 120hz, allowing 10% margin
         float misses60 = arrivalDeltas.Count(d => (d - (1f / 60f)) > (0.1f / 60f));
 
         // Find deltas larger than expected at 120hz, allowing 10% margin
         float misses120 = arrivalDeltas.Count(d => (d - (1f / 120f)) > (0.1f / 120f));
 
+        // Allow 1/120 missed for good
+        // Allow 0/60 missed for subpar
+        string statusText = misses120 <= 2 ? "Good" : (misses60 <= 1 ? "Subpar" : "Poor")
+
         string message = $"""
-            RLBot @ {averageTickRate:0}hz {(1f - misses60 / 120f) * 100f:0}%|{(
-                1f - misses120 / 120f
-            ) * 100f:0}%
+            RLBot @ {averageTickRate:0}hz {(1f - missesAdaptive / 120f) * 100f:0}% {statusText}
              p95 {GetPercentile(arrivalDeltas, 0.95f) * 1000f:0.0}ms p99 {GetPercentile(
                 arrivalDeltas,
                 0.99f
             ) * 1000f:0.0}ms
             """;
-        bool shouldRender = misses120 > 1;
+        bool shouldRender = misses120 > 0;
 
         foreach (var (name, samples) in _samples)
         {

--- a/RLBotCS/ManagerTools/PerfMonitor.cs
+++ b/RLBotCS/ManagerTools/PerfMonitor.cs
@@ -90,7 +90,7 @@ public class PerfMonitor
 
         // Allow 1/120 missed for good
         // Allow 0/60 missed for subpar
-        string statusText = misses120 <= 2 ? "Good" : (misses60 <= 1 ? "Subpar" : "Poor")
+        string statusText = misses120 <= 2 ? "Good" : (misses60 <= 1 ? "Subpar" : "Poor");
 
         string message = $"""
             RLBot @ {averageTickRate:0}hz {(1f - missesAdaptive / 120f) * 100f:0}% {statusText}

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -100,7 +100,8 @@ class BridgeHandler(
                 {
                     // Only track ticks where time advanced, the api actually sends more
                     // clumps, but we don't care about those.
-                    float arrivalDeltaTime = (float)Stopwatch.GetElapsedTime(lastNewTickTimestamp).TotalSeconds;
+                    float arrivalDeltaTime = (float)
+                        Stopwatch.GetElapsedTime(lastNewTickTimestamp).TotalSeconds;
                     lastNewTickTimestamp = Stopwatch.GetTimestamp();
 
                     _context.PerfMonitor.AddRLBotSample((deltaTime, arrivalDeltaTime));

--- a/RLBotCS/Server/BridgeHandler.cs
+++ b/RLBotCS/Server/BridgeHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading.Channels;
 using Bridge.Conversion;
 using Bridge.TCP;
@@ -57,6 +58,7 @@ class BridgeHandler(
         _context.Logger.LogInformation("Connected to Rocket League");
 
         bool isFirstTick = true;
+        long lastNewTickTimestamp = Stopwatch.GetTimestamp();
 
         await foreach (var messageClump in _context.Messenger.ReadAllAsync())
         {
@@ -95,7 +97,14 @@ class BridgeHandler(
                 _context.ticksSinceMapLoad += 1;
 
                 if (timeAdvanced)
-                    _context.PerfMonitor.AddRLBotSample(deltaTime);
+                {
+                    // Only track ticks where time advanced, the api actually sends more
+                    // clumps, but we don't care about those.
+                    float arrivalDeltaTime = (float)Stopwatch.GetElapsedTime(lastNewTickTimestamp).TotalSeconds;
+                    lastNewTickTimestamp = Stopwatch.GetTimestamp();
+
+                    _context.PerfMonitor.AddRLBotSample((deltaTime, arrivalDeltaTime));
+                }
 
                 ConsiderDistributingPacket(_context, timeAdvanced);
 


### PR DESCRIPTION
The perfmonitor now shows more info. It shows actual "packet-arrival-in-time"-rate instead of the old packet-arrival-rate. It also shows p95 and p99 values for packet arrival deltas. It looks like this when running the game at 144hz.
<img width="236" height="44" alt="image" src="https://github.com/user-attachments/assets/fc55087c-a086-46b5-9ee9-0183b6ecb8fd" />
First percentage is ticks that arrived in time for a 60hz arrival rate, second one is ticks that arrived in time for a 120hz arrival rate. Running the game at a stable 120hz yields a 100% on both, 60hz yields `100%|0%` and 30hz yields `0%|0%`. This enables you to show if RLBot is *actually* delivering a stable packet stream to bots. Also see [related violin plot of packet arrival rate at 144hz](https://discord.com/channels/348658686962696195/423167304956903428/1418642306382172161).