### PR TITLE
Warn about possibly invalid map names

### DIFF
--- a/RLBotCS/Conversion/FlatToCommand.cs
+++ b/RLBotCS/Conversion/FlatToCommand.cs
@@ -404,9 +404,23 @@ static class FlatToCommand
                 customMap = new(matchConfig.GameMapUpk);
                 command += CustomMap.RL_MAP_KEY;
             }
-            else
+             else
             {
-                command += matchConfig.GameMapUpk;
+                // Warn if the map name doesn't look like a valid official or custom map.
+                // Official maps end with _p or _P, custom maps end with .upk or .udk.
+                string mapUpk = matchConfig.GameMapUpk;
+                bool isOfficialMap = mapUpk.EndsWith("_p", StringComparison.OrdinalIgnoreCase);
+                bool isCustomMapExtension =
+                    mapUpk.EndsWith(".upk", StringComparison.OrdinalIgnoreCase)
+                    || mapUpk.EndsWith(".udk", StringComparison.OrdinalIgnoreCase);
+                if (!isOfficialMap && !isCustomMapExtension)
+                {
+                    Logger.LogWarning(
+                        $"Map name '{mapUpk}' does not end with '_p'/'_P' (official maps) or '.upk'/'.udk' (custom maps). "
+                            + "The map may fail to load. Official map names should end with '_p', e.g. 'Stadium_P'."
+                    );
+                }
+                command += mapUpk;
             }
         }
         else

--- a/RLBotCS/Conversion/FlatToCommand.cs
+++ b/RLBotCS/Conversion/FlatToCommand.cs
@@ -404,7 +404,7 @@ static class FlatToCommand
                 customMap = new(matchConfig.GameMapUpk);
                 command += CustomMap.RL_MAP_KEY;
             }
-             else
+            else
             {
                 // Warn if the map name doesn't look like a valid official or custom map.
                 // Official maps end with _p or _P, custom maps end with .upk or .udk.

--- a/RLBotCS/Server/FlatBuffersServer.cs
+++ b/RLBotCS/Server/FlatBuffersServer.cs
@@ -84,7 +84,7 @@ class FlatBuffersServer(
             }
     }
 
-    private async Task HandleServer()
+ private async Task HandleServer()
     {
         try
         {
@@ -104,6 +104,18 @@ class FlatBuffersServer(
                     AddSession(client);
                 }
             }
+        }
+        catch (SocketException e) when (e.SocketErrorCode == SocketError.AddressAlreadyInUse)
+        {
+            _context.Logger.LogError(
+                $"Port {rlbotPort} is already in use. Is another instance of RLBot already running?"
+            );
+        }
+        catch (SocketException e) when (e.SocketErrorCode == SocketError.OperationAborted)
+        {
+            // This happens during normal shutdown when the server is stopped while waiting
+            // for a connection. Not an error.
+            _context.Logger.LogDebug("Server stopped while waiting for connections.");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Closes #133

Emits a `LogWarning` in `MakeOpenCommand` when `GameMapUpk` doesn't end with `_p`/`_P` (official maps) or `.upk`/`.udk` (custom map file paths), since an invalid map name will cause the match to fail to load with no helpful feedback to the user.