### PR TITLE
Out of mem

### DIFF
--- a/RLBotCS/Main.cs
+++ b/RLBotCS/Main.cs
@@ -10,7 +10,7 @@ using RLBotCS.Server.ServerMessage;
 if (args.Length > 0 && args[0] == "--version")
 {
     Console.WriteLine(
-        "RLBotServer v5.0.0-rc.7\n"
+        "RLBotServer v5.0.0-rc.8\n"
             + $"Bridge {BridgeVersion.Version}\n"
             + "@ https://www.rlbot.org & https://github.com/RLBot/core"
     );

--- a/RLBotCS/ManagerTools/WinReadLog.cs
+++ b/RLBotCS/ManagerTools/WinReadLog.cs
@@ -45,25 +45,37 @@ public class WinReadLog
         if (!File.Exists(LogPath))
             return null;
 
-        string logContent = File.ReadAllText(LogPath);
+        string? auth = null;
+        string? path = null;
 
-        int authPrefixIndex = logContent.IndexOf(AUTH_LINE_PREFIX, StringComparison.Ordinal);
-        int pathPrefixIndex = logContent.IndexOf(PATH_LINE_PREFIX, StringComparison.Ordinal);
-        if (authPrefixIndex == -1 || pathPrefixIndex == -1)
-            return null;
+        using var reader = new StreamReader(
+            LogPath,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true
+        );
 
-        int authStart = authPrefixIndex + AUTH_LINE_PREFIX.Length;
-        int pathStart = pathPrefixIndex + PATH_LINE_PREFIX.Length;
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (auth == null && line.StartsWith(AUTH_LINE_PREFIX, StringComparison.Ordinal))
+            {
+                auth = line[AUTH_LINE_PREFIX.Length..].TrimEnd('\r', '\n');
+            }
+            else if (
+                path == null
+                && line.StartsWith(PATH_LINE_PREFIX, StringComparison.Ordinal)
+            )
+            {
+                path = line[PATH_LINE_PREFIX.Length..].TrimEnd('\r', '\n');
+            }
 
-        int authEnd = logContent.IndexOf('\n', authStart);
-        int pathEnd = logContent.IndexOf('\n', pathStart);
-        if (authEnd == -1 || pathEnd == -1)
-            return null;
+            if (auth != null && path != null)
+            {
+                return (Path.Combine(path, BINARY_NAME), auth);
+            }
+        }
 
-        string auth = logContent[authStart..authEnd].TrimEnd('\r', '\n');
-        string path = logContent[pathStart..pathEnd].TrimEnd('\r', '\n');
-
-        return (Path.Combine(path, BINARY_NAME), auth);
+        return null;
     }
 }
 #endif


### PR DESCRIPTION
If the log file is too big, reading the whole thing might fill up system RAM:
```
System.OutOfMemoryException: Insufficient memory to continue the execution of the program.
   at System.Text.StringBuilder.ExpandByABlock(Int32) + 0x127
   at System.Text.StringBuilder.AppendWithExpansion(Char&, Int32) + 0x9a
   at System.Text.StringBuilder.Append(Char[], Int32, Int32) + 0x45
   at System.IO.StreamReader.ReadToEnd() + 0x56
   at System.IO.File.ReadAllText(String, Encoding) + 0x77
   at WinReadLog.GetGamePathAndAuth() + 0x60
   at RLBotCS.ManagerTools.LaunchManager.LaunchRocketLeague(Launcher, String, Int32) + 0x460
   at RLBotCS.ManagerTools.MatchStarter.StartMatch(MatchConfigurationT, PlayerSpawner) + 0x69
   at RLBotCS.Server.BridgeMessage.StartMatch.HandleMessage(BridgeContext) + 0x85
   at RLBotCS.Server.BridgeHandler.<HandleInternalMessages>d__5.MoveNext() + 0x34e
```

We now stream the file line-by-line to improve RAM efficiency when trying to read the log.