### PR TITLE
Implement lookup-table-based rectangle approximation.

### DIFF
--- a/RLBotCS/ManagerTools/RectUtil.cs
+++ b/RLBotCS/ManagerTools/RectUtil.cs
@@ -5,24 +5,14 @@ namespace RLBotCS.ManagerTools;
 public static class RectUtil
 {
     /// <summary>
-    /// Defines the maximum represented aspect ratio (<tt>Limit</tt>/1)
-    /// as well as the granularity of stored ratios.<br/>
-    /// Number of entries and the total resulting size in memory
-    /// for different <tt>Limit</tt> values are as follows:
-    /// <code>
-    /// ┌───────┬─────────┬────────────┐
-    /// │ Limit │ entries │    size    │
-    /// ├───────┼─────────┼────────────┤
-    /// │   512 │   1174  │   9.17 kiB │
-    /// │  1024 │   2563  │  20.02 kiB │
-    /// │  2048 │   5555  │  43.4  kiB │
-    /// │  4096 │  11977  │  93.57 kiB │
-    /// │  8192 │  25673  │ 200.57 kiB │
-    /// │ 16384 │  54778  │ 427.95 kiB │
-    /// └───────┴─────────┴────────────┘
-    /// </code>
+    /// The maximum number of subdivisions of the [0,1] interval to store.
+    /// The maximum possible resulting number of entries is ⌈<tt>MaxSubdivisions</tt>/2⌉,
+    /// but only those whose sum of the numerator and denominator does
+    /// not excede <tt>Rendering.RectangleStringMaxLength</tt> are included,
+    /// so ideally this should be a highly composite number.<br/>
+    /// For 55440, there are 17635 entries, corresponding to 137.77 kiB of memory.
     /// </summary>
-    public const ushort Limit = 4096;
+    private const ushort MaxSubdivisions = 55440;
 
     private const float HalfPrecisionRangeHigh = 4096f;
     private const float HalfPrecisionRangeLow = 1.0f / HalfPrecisionRangeHigh;
@@ -32,8 +22,6 @@ public static class RectUtil
 
     static RectUtil()
     {
-        SortedDictionary<float, (ushort, ushort)> dictionary = [];
-
         static int Gcd(int a, int b)
         {
             // Greatest common divisor by Euclidean algorithm https://stackoverflow.com/a/41766138
@@ -48,10 +36,16 @@ public static class RectUtil
             return a | b;
         }
 
-        for (ushort a = 1; a <= Limit; ++a)
-        for (ushort b = 1; b <= a && a * b <= Limit; ++b)
-            if (Gcd(a, b) == 1)
-                dictionary.Add((float)a / b, (a, b));
+        SortedDictionary<float, (ushort, ushort)> dictionary = [];
+        float fMaxSubdivisions = MaxSubdivisions;
+        for (ushort i = MaxSubdivisions / 2 + MaxSubdivisions % 2; i <= MaxSubdivisions; ++i)
+        {
+            ushort gcd = (ushort)Gcd(i, MaxSubdivisions);
+            ushort num = (ushort)(i / gcd);
+            ushort den = (ushort)(MaxSubdivisions / gcd);
+            if (num + den <= Rendering.RectangleStringMaxLength)
+                dictionary.Add(i / fMaxSubdivisions, (num, den));
+        }
 
         ratios = [.. dictionary.Keys];
         rects = [.. dictionary.Values];
@@ -69,14 +63,7 @@ public static class RectUtil
         return MathF.Sqrt(a * b);
     }
 
-    private static bool LessThanGeoMean(float x, (float a, float b) m)
-    {
-        if (m.b >= HalfPrecisionRangeHigh)
-            return x < MathF.Sqrt(m.a) * MathF.Sqrt(m.b);
-        return x * x < m.a * m.b;
-    }
-
-    private static (ushort, ushort) Find(float value)
+    private static (ushort, ushort) FindImpl(float value)
     {
         int higherIdx = ratios.BinarySearch(value);
 
@@ -85,24 +72,30 @@ public static class RectUtil
 
         higherIdx = ~higherIdx;
 
-        // No need to handle this because value >= 1.0 == ratios.First()
+        // No need to handle this because value >= 0.5 == ratios.First()
         //if (higherIdx == 0)
         //    return rects.First();
 
-        if (higherIdx == ratios.Length)
-            return rects.Last();
+        // No need to handle this because value <= 1.0 == ratios.Last()
+        //if (higherIdx == ratios.Length)
+        //    return rects.Last();
 
         int lowerIdx = higherIdx - 1;
-        return rects[
-            LessThanGeoMean(value, (ratios[lowerIdx], ratios[higherIdx]))
-                ? lowerIdx
-                : higherIdx
-        ];
+        return rects[value * 2 < ratios[lowerIdx] + ratios[higherIdx] ? lowerIdx : higherIdx];
+    }
+
+    private static (ushort, ushort) Find(float value)
+    {
+        if (value >= 0.5)
+            return FindImpl(value);
+
+        (ushort num, ushort den) = FindImpl(1f - value);
+        return ((ushort)(den - num), den);
     }
 
     private static (ushort cols, ushort rows) Find(float width, float height)
     {
-        if (width >= height)
+        if (width <= height)
             return Find(width / height);
 
         (ushort rows, ushort cols) = Find(height / width);
@@ -114,10 +107,10 @@ public static class RectUtil
     /// rectangles with dimensions <tt>elementWidth</tt>×<tt>elementHeight</tt> scaled by <tt>scale</tt>.
     /// </summary>
     public static (ushort cols, ushort rows, float scale) ApproximateRect(
-        int width,
-        int height,
-        int elementWidth,
-        int elementHeight
+        uint width,
+        uint height,
+        uint elementWidth,
+        uint elementHeight
     )
     {
         float elementsInWidth = (float)width / elementWidth;

--- a/RLBotCS/ManagerTools/RectUtil.cs
+++ b/RLBotCS/ManagerTools/RectUtil.cs
@@ -49,9 +49,9 @@ public static class RectUtil
         }
 
         for (ushort a = 1; a <= Limit; ++a)
-            for (ushort b = 1; b <= a && a * b <= Limit; ++b)
-                if (Gcd(a, b) == 1)
-                    dictionary.Add((float)a / b, (a, b));
+        for (ushort b = 1; b <= a && a * b <= Limit; ++b)
+            if (Gcd(a, b) == 1)
+                dictionary.Add((float)a / b, (a, b));
 
         ratios = [.. dictionary.Keys];
         rects = [.. dictionary.Values];
@@ -59,15 +59,23 @@ public static class RectUtil
 
     private static float GeoMean(float a, float b)
     {
-        if (a >= HalfPrecisionRangeHigh || b >= HalfPrecisionRangeHigh ||
-            a <= HalfPrecisionRangeLow || b <= HalfPrecisionRangeLow)
+        if (
+            a >= HalfPrecisionRangeHigh
+            || b >= HalfPrecisionRangeHigh
+            || a <= HalfPrecisionRangeLow
+            || b <= HalfPrecisionRangeLow
+        )
             return MathF.Sqrt(a) * MathF.Sqrt(b);
         return MathF.Sqrt(a * b);
     }
 
     private static bool LessThanGeoMean(float x, (float a, float b) m)
     {
-        if (x >= HalfPrecisionRangeHigh || m.a >= HalfPrecisionRangeHigh || m.b >= HalfPrecisionRangeHigh)
+        if (
+            x >= HalfPrecisionRangeHigh
+            || m.a >= HalfPrecisionRangeHigh
+            || m.b >= HalfPrecisionRangeHigh
+        )
             return x < MathF.Sqrt(m.a) * MathF.Sqrt(m.b);
         return x * x < m.a * m.b;
     }
@@ -89,7 +97,11 @@ public static class RectUtil
             return rects.Last();
 
         int lowerIdx = higherIdx - 1;
-        return rects[LessThanGeoMean(value, (ratios[lowerIdx], ratios[higherIdx])) ? lowerIdx : higherIdx];
+        return rects[
+            LessThanGeoMean(value, (ratios[lowerIdx], ratios[higherIdx]))
+                ? lowerIdx
+                : higherIdx
+        ];
     }
 
     private static (ushort cols, ushort rows) Find(float width, float height)
@@ -105,7 +117,12 @@ public static class RectUtil
     /// Approximates the rectangle <tt>width</tt>×<tt>height</tt> with <tt>cols</tt>×<tt>rows</tt>
     /// rectangles with dimensions <tt>elementWidth</tt>×<tt>elementHeight</tt> scaled by <tt>scale</tt>.
     /// </summary>
-    public static (ushort cols, ushort rows, float scale) ApproximateRect(int width, int height, int elementWidth, int elementHeight)
+    public static (ushort cols, ushort rows, float scale) ApproximateRect(
+        int width,
+        int height,
+        int elementWidth,
+        int elementHeight
+    )
     {
         float elementsInWidth = (float)width / elementWidth;
         float elementsInHeight = (float)height / elementHeight;

--- a/RLBotCS/ManagerTools/RectUtil.cs
+++ b/RLBotCS/ManagerTools/RectUtil.cs
@@ -1,0 +1,119 @@
+using System.Collections.Immutable;
+
+namespace RLBotCS.ManagerTools;
+
+public static class RectUtil
+{
+    /// <summary>
+    /// Defines the maximum represented aspect ratio (<tt>Limit</tt>/1)
+    /// as well as the granularity of stored ratios.<br/>
+    /// Number of entries and the total resulting size in memory
+    /// for different <tt>Limit</tt> values are as follows:
+    /// <code>
+    /// ┌───────┬─────────┬────────────┐
+    /// │ Limit │ entries │    size    │
+    /// ├───────┼─────────┼────────────┤
+    /// │   512 │   1174  │   9.17 kiB │
+    /// │  1024 │   2563  │  20.02 kiB │
+    /// │  2048 │   5555  │  43.4  kiB │
+    /// │  4096 │  11977  │  93.57 kiB │
+    /// │  8192 │  25673  │ 200.57 kiB │
+    /// │ 16384 │  54778  │ 427.95 kiB │
+    /// └───────┴─────────┴────────────┘
+    /// </code>
+    /// </summary>
+    public const ushort Limit = 4096;
+
+    private const float HalfPrecisionRangeHigh = 4096f;
+    private const float HalfPrecisionRangeLow = 1.0f / HalfPrecisionRangeHigh;
+
+    private static readonly ImmutableArray<float> ratios;
+    private static readonly ImmutableArray<(ushort, ushort)> rects;
+
+    static RectUtil()
+    {
+        SortedDictionary<float, (ushort, ushort)> dictionary = [];
+
+        static int Gcd(int a, int b)
+        {
+            // Greatest common divisor by Euclidean algorithm https://stackoverflow.com/a/41766138
+            while (a != 0 && b != 0)
+            {
+                if (a > b)
+                    a %= b;
+                else
+                    b %= a;
+            }
+
+            return a | b;
+        }
+
+        for (ushort a = 1; a <= Limit; ++a)
+            for (ushort b = 1; b <= a && a * b <= Limit; ++b)
+                if (Gcd(a, b) == 1)
+                    dictionary.Add((float)a / b, (a, b));
+
+        ratios = [.. dictionary.Keys];
+        rects = [.. dictionary.Values];
+    }
+
+    private static float GeoMean(float a, float b)
+    {
+        if (a >= HalfPrecisionRangeHigh || b >= HalfPrecisionRangeHigh ||
+            a <= HalfPrecisionRangeLow || b <= HalfPrecisionRangeLow)
+            return MathF.Sqrt(a) * MathF.Sqrt(b);
+        return MathF.Sqrt(a * b);
+    }
+
+    private static bool LessThanGeoMean(float x, (float a, float b) m)
+    {
+        if (x >= HalfPrecisionRangeHigh || m.a >= HalfPrecisionRangeHigh || m.b >= HalfPrecisionRangeHigh)
+            return x < MathF.Sqrt(m.a) * MathF.Sqrt(m.b);
+        return x * x < m.a * m.b;
+    }
+
+    private static (ushort, ushort) Find(float value)
+    {
+        int higherIdx = ratios.BinarySearch(value);
+
+        if (higherIdx >= 0)
+            return rects[higherIdx];
+
+        higherIdx = ~higherIdx;
+
+        // No need to handle this because value >= 1.0 == ratios.First()
+        //if (higherIdx == 0)
+        //    return rects.First();
+
+        if (higherIdx == ratios.Length)
+            return rects.Last();
+
+        int lowerIdx = higherIdx - 1;
+        return rects[LessThanGeoMean(value, (ratios[lowerIdx], ratios[higherIdx])) ? lowerIdx : higherIdx];
+    }
+
+    private static (ushort cols, ushort rows) Find(float width, float height)
+    {
+        if (width >= height)
+            return Find(width / height);
+
+        (ushort rows, ushort cols) = Find(height / width);
+        return (cols, rows);
+    }
+
+    /// <summary>
+    /// Approximates the rectangle <tt>width</tt>×<tt>height</tt> with <tt>cols</tt>×<tt>rows</tt>
+    /// rectangles with dimensions <tt>elementWidth</tt>×<tt>elementHeight</tt> scaled by <tt>scale</tt>.
+    /// </summary>
+    public static (ushort cols, ushort rows, float scale) ApproximateRect(int width, int height, int elementWidth, int elementHeight)
+    {
+        float elementsInWidth = (float)width / elementWidth;
+        float elementsInHeight = (float)height / elementHeight;
+        (ushort cols, ushort rows) = Find(elementsInWidth, elementsInHeight);
+
+        // Ideal horizontal and vertical scale are
+        // ((float)width / cols) / elementWidth == ((float)width / elementWidth) / cols == elementsInWidth / cols
+        // ((float)height / rows) / elementHeight == ((float)height / elementHeight) / rows == elementsInHeight / rows
+        return (cols, rows, GeoMean(elementsInWidth / cols, elementsInHeight / rows));
+    }
+}

--- a/RLBotCS/ManagerTools/RectUtil.cs
+++ b/RLBotCS/ManagerTools/RectUtil.cs
@@ -71,7 +71,7 @@ public static class RectUtil
 
     private static bool LessThanGeoMean(float x, (float a, float b) m)
     {
-        if (m.a >= HalfPrecisionRangeHigh || m.b >= HalfPrecisionRangeHigh)
+        if (m.b >= HalfPrecisionRangeHigh)
             return x < MathF.Sqrt(m.a) * MathF.Sqrt(m.b);
         return x * x < m.a * m.b;
     }

--- a/RLBotCS/ManagerTools/RectUtil.cs
+++ b/RLBotCS/ManagerTools/RectUtil.cs
@@ -71,11 +71,7 @@ public static class RectUtil
 
     private static bool LessThanGeoMean(float x, (float a, float b) m)
     {
-        if (
-            x >= HalfPrecisionRangeHigh
-            || m.a >= HalfPrecisionRangeHigh
-            || m.b >= HalfPrecisionRangeHigh
-        )
+        if (m.a >= HalfPrecisionRangeHigh || m.b >= HalfPrecisionRangeHigh)
             return x < MathF.Sqrt(m.a) * MathF.Sqrt(m.b);
         return x * x < m.a * m.b;
     }

--- a/RLBotCS/ManagerTools/Rendering.cs
+++ b/RLBotCS/ManagerTools/Rendering.cs
@@ -137,35 +137,9 @@ public class Rendering(TcpMessenger tcpMessenger)
     /// <returns>The rectangle string and the font scaling</returns>
     private (string, float) MakeFakeRectangleString(int width, int height)
     {
-        int Gcd(int a, int b)
-        {
-            // Greatest common divisor by Euclidean algorithm https://stackoverflow.com/a/41766138
-            while (a != 0 && b != 0)
-            {
-                if (a > b)
-                    a %= b;
-                else
-                    b %= a;
-            }
+        (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(width, height, FontWidthPixels, FontHeightPixels);
 
-            return a | b;
-        }
-
-        int gcd = Gcd(width, height);
-        int cols = (width / gcd) * (FontHeightPixels / FontWidthPixels);
-        int rows = height / gcd;
-        float scale = gcd / (float)FontHeightPixels;
-
-        if (cols + rows > RectangleStringMaxLength)
-        {
-            // The width-height ratio has resulting in a very long string.
-            // TODO: Consider an approximate solution as backup. Do we ever hit this case though?
-            Logger.LogWarning(
-                "A rendered rectangle requires more characters than budget allows. Consider different width-height ratio."
-            );
-        }
-
-        StringBuilder str = new StringBuilder(cols + rows);
+        StringBuilder str = new(cols + rows);
         for (int c = 0; c < cols; c++)
         {
             str.Append(' ');

--- a/RLBotCS/ManagerTools/Rendering.cs
+++ b/RLBotCS/ManagerTools/Rendering.cs
@@ -137,7 +137,12 @@ public class Rendering(TcpMessenger tcpMessenger)
     /// <returns>The rectangle string and the font scaling</returns>
     private (string, float) MakeFakeRectangleString(int width, int height)
     {
-        (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(width, height, FontWidthPixels, FontHeightPixels);
+        (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(
+            width,
+            height,
+            FontWidthPixels,
+            FontHeightPixels
+        );
 
         StringBuilder str = new(cols + rows);
         for (int c = 0; c < cols; c++)

--- a/RLBotCS/ManagerTools/Rendering.cs
+++ b/RLBotCS/ManagerTools/Rendering.cs
@@ -94,8 +94,8 @@ public class Rendering(TcpMessenger tcpMessenger)
 
         // Fake a filled rectangle using a string with colored background
         var (text, scale) = MakeFakeRectangleString(
-            (int)Math.Abs(rect2Dt.Width * ResolutionWidthPixels),
-            (int)Math.Abs(rect2Dt.Height * ResolutionHeightPixels)
+            (uint)Math.Abs(rect2Dt.Width * ResolutionWidthPixels),
+            (uint)Math.Abs(rect2Dt.Height * ResolutionHeightPixels)
         );
 
         return _renderingCommandQueue.AddText2D(
@@ -114,8 +114,8 @@ public class Rendering(TcpMessenger tcpMessenger)
     {
         // Fake a filled rectangle using a string with colored background
         var (text, scale) = MakeFakeRectangleString(
-            (int)Math.Abs(rect3Dt.Width * ResolutionWidthPixels),
-            (int)Math.Abs(rect3Dt.Height * ResolutionHeightPixels)
+            (uint)Math.Abs(rect3Dt.Width * ResolutionWidthPixels),
+            (uint)Math.Abs(rect3Dt.Height * ResolutionHeightPixels)
         );
 
         return _renderingCommandQueue.AddText3D(
@@ -135,7 +135,7 @@ public class Rendering(TcpMessenger tcpMessenger)
     /// for rectangle rendering.
     /// </summary>
     /// <returns>The rectangle string and the font scaling</returns>
-    private (string, float) MakeFakeRectangleString(int width, int height)
+    private (string, float) MakeFakeRectangleString(uint width, uint height)
     {
         (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(
             width,

--- a/RLBotCSTests/ManagerTools/RectUtilTest.cs
+++ b/RLBotCSTests/ManagerTools/RectUtilTest.cs
@@ -13,7 +13,7 @@ public class RectUtilTest
     {
         for (int i = 1; i <= TestUpTo; ++i)
         {
-            for(int j = 1; j <= TestUpTo; ++j)
+            for (int j = 1; j <= TestUpTo; ++j)
             {
                 (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(i, i, j, j);
                 Assert.AreEqual(1, cols);
@@ -35,7 +35,12 @@ public class RectUtilTest
                 {
                     for (int l = 1; l <= TestUpTo; ++l)
                     {
-                        (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(i, j, k, l);
+                        (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(
+                            i,
+                            j,
+                            k,
+                            l
+                        );
                         Assert.IsInRange(iMin, iMax, k * scale * cols);
                         Assert.IsInRange(jMin, jMax, l * scale * rows);
                     }

--- a/RLBotCSTests/ManagerTools/RectUtilTest.cs
+++ b/RLBotCSTests/ManagerTools/RectUtilTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RLBotCS.ManagerTools;
+
+namespace RLBotCSTests.ManagerTools;
+
+[TestClass]
+public class RectUtilTest
+{
+    const int TestUpTo = 64;
+
+    [TestMethod]
+    public void ApproximateRectTest()
+    {
+        for (int i = 1; i <= TestUpTo; ++i)
+        {
+            for(int j = 1; j <= TestUpTo; ++j)
+            {
+                (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(i, i, j, j);
+                Assert.AreEqual(1, cols);
+                Assert.AreEqual(1, rows);
+                // Slightly iffy, but it passes.
+                Assert.AreEqual((float)i / j, scale);
+            }
+        }
+
+        for (int i = 1; i <= TestUpTo; ++i)
+        {
+            float iMin = i * 0.95f;
+            float iMax = i * 1.05f;
+            for (int j = 1; j <= TestUpTo; ++j)
+            {
+                float jMin = j * 0.95f;
+                float jMax = j * 1.05f;
+                for (int k = 1; k <= TestUpTo; ++k)
+                {
+                    for (int l = 1; l <= TestUpTo; ++l)
+                    {
+                        (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(i, j, k, l);
+                        Assert.IsInRange(iMin, iMax, k * scale * cols);
+                        Assert.IsInRange(jMin, jMax, l * scale * rows);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RLBotCSTests/ManagerTools/RectUtilTest.cs
+++ b/RLBotCSTests/ManagerTools/RectUtilTest.cs
@@ -6,14 +6,14 @@ namespace RLBotCSTests.ManagerTools;
 [TestClass]
 public class RectUtilTest
 {
-    const int TestUpTo = 64;
+    const uint TestUpTo = 64;
 
     [TestMethod]
     public void ApproximateRectTest()
     {
-        for (int i = 1; i <= TestUpTo; ++i)
+        for (uint i = 1; i <= TestUpTo; ++i)
         {
-            for (int j = 1; j <= TestUpTo; ++j)
+            for (uint j = 1; j <= TestUpTo; ++j)
             {
                 (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(i, i, j, j);
                 Assert.AreEqual(1, cols);
@@ -23,17 +23,17 @@ public class RectUtilTest
             }
         }
 
-        for (int i = 1; i <= TestUpTo; ++i)
+        for (uint i = 1; i <= TestUpTo; ++i)
         {
-            float iMin = i * 0.95f;
-            float iMax = i * 1.05f;
-            for (int j = 1; j <= TestUpTo; ++j)
+            float iMin = i * 0.96f;
+            float iMax = i * 1.04f;
+            for (uint j = 1; j <= TestUpTo; ++j)
             {
-                float jMin = j * 0.95f;
-                float jMax = j * 1.05f;
-                for (int k = 1; k <= TestUpTo; ++k)
+                float jMin = j * 0.96f;
+                float jMax = j * 1.04f;
+                for (uint k = 1; k <= TestUpTo; ++k)
                 {
-                    for (int l = 1; l <= TestUpTo; ++l)
+                    for (uint l = 1; l <= TestUpTo; ++l)
                     {
                         (ushort cols, ushort rows, float scale) = RectUtil.ApproximateRect(
                             i,


### PR DESCRIPTION
Rectangle approximation using a precomputed lookup table has been implemented, for use in `MakeFakeRectangleString`. ~~Even though this method produces a string of length `rows+cols-1`, the ratio limit in table precomputation is based on `rows*cols` because this produces a better ratio value distribution for a given lookup table size.~~

An additional accompanying unit test has also been implemented.

Edit: The value generation strategy has been significantly refactored.