### PR TITLE
Build in container + update tomlyn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,24 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm-slim
 
     steps:
+      - name: Install prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends clang lld
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: "recursive"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
 
       - name: Test
         run: dotnet test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends clang lld git
+          apt-get install -y --no-install-recommends ca-certificates clang lld git
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends clang lld
+          apt-get install -y --no-install-recommends clang lld git
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends ca-certificates clang lld git
+          apt-get install -y --no-install-recommends ca-certificates clang lld git curl
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
           submodules: "recursive"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -142,8 +142,9 @@ public class ConfigParser
             }
 
             path = Path.GetFullPath(path);
+            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             return TomlSerializer.Deserialize<TomlTable>(
-                File.Open(path, FileMode.Open),
+                stream,
                 ParserTomlContext.Default
             )!;
         }

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -4,6 +4,7 @@ using RLBot.Flat;
 using RLBotCS.Model;
 using Tomlyn;
 using Tomlyn.Model;
+using Tomlyn.Serialization;
 
 namespace RLBotCS.ManagerTools;
 
@@ -16,6 +17,7 @@ public class ConfigParser
         public const string RlBotLauncherArg = "launcher_arg";
         public const string RlBotAutoStartAgents = "auto_start_agents";
         public const string RlBotWaitForAgents = "wait_for_agents";
+        public const string RlBotPerformanceMonitor = "performance_monitor";
 
         public const string MatchTable = "match";
         public const string MatchGameMode = "game_mode";
@@ -27,7 +29,6 @@ public class ConfigParser
         public const string MatchStateSetting = "enable_state_setting";
         public const string MatchAutoSaveReplays = "auto_save_replays";
         public const string MatchFreePlay = "freeplay";
-        public const string MatchPerformanceMonitor = "performance_monitor";
 
         public const string MutatorsTable = "mutators";
         public const string MutatorsMatchLength = "match_length";
@@ -112,7 +113,21 @@ public class ConfigParser
     private readonly ConfigContextTracker _context = new();
 
     /// <summary>Holds field names that were not present in the config. Used for debugging.</summary>
-    private readonly List<string> _missingValues = new();
+    private readonly List<string> _missingValues = [];
+
+    /// <summary>
+    /// AOT-safe TOML serializer context for parsing documents into <see cref="TomlTable"/>.
+    /// </summary>
+    private sealed class ParserTomlContext : TomlSerializerContext
+    {
+        public static readonly ParserTomlContext Default = new();
+
+        private ParserTomlContext()
+            : base(new()) { }
+
+        public override TomlTypeInfo? GetTypeInfo(Type type, TomlSerializerOptions options) =>
+            type == typeof(TomlTable) ? GetBuiltInTypeInfo<TomlTable>(options) : null;
+    }
 
     private TomlTable LoadTomlFile(string path)
     {
@@ -127,7 +142,10 @@ public class ConfigParser
             }
 
             path = Path.GetFullPath(path);
-            return Toml.ToModel(File.ReadAllText(path), path);
+            return TomlSerializer.Deserialize<TomlTable>(
+                File.Open(path, FileMode.Open),
+                ParserTomlContext.Default
+            )!;
         }
         catch (Exception e)
         {
@@ -729,7 +747,7 @@ public class ConfigParser
             path = Path.GetFullPath(path);
             TomlTable outerTable = LoadTomlFile(path);
 
-            MatchConfigurationT matchConfig = new MatchConfigurationT();
+            MatchConfigurationT matchConfig = new();
 
             TomlTable rlbotTable = GetValue<TomlTable>(outerTable, Fields.RlBotTable, []);
             using (_context.Begin(Fields.RlBotTable))
@@ -752,7 +770,7 @@ public class ConfigParser
                 );
                 matchConfig.PerformanceMonitor = GetEnum(
                     rlbotTable,
-                    Fields.MatchPerformanceMonitor,
+                    Fields.RlBotPerformanceMonitor,
                     PerformanceMonitor.ShowWhenSuboptimal
                 );
             }

--- a/RLBotCS/ManagerTools/ConfigParser.cs
+++ b/RLBotCS/ManagerTools/ConfigParser.cs
@@ -143,10 +143,7 @@ public class ConfigParser
 
             path = Path.GetFullPath(path);
             using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return TomlSerializer.Deserialize<TomlTable>(
-                stream,
-                ParserTomlContext.Default
-            )!;
+            return TomlSerializer.Deserialize<TomlTable>(stream, ParserTomlContext.Default)!;
         }
         catch (Exception e)
         {

--- a/RLBotCS/RLBotCS.csproj
+++ b/RLBotCS/RLBotCS.csproj
@@ -10,16 +10,14 @@
     <OptimizationPreference>Speed</OptimizationPreference>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-    <PublishWmiLightStaticallyLinked>true</PublishWmiLightStaticallyLinked>
     <SelfContained>true</SelfContained>
-    <StaticExecutable>true</StaticExecutable>
     <LinkerFlavor
       Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'"
       >lld</LinkerFlavor>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Tomlyn" Version="0.20.0" />
+    <PackageReference Include="Tomlyn" Version="2.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
   </ItemGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
- Build inside debian:bookworm-slim container (same as botpack) and dynamically link glibc (2.36) again on Linux
- Migrate to tomlyn 2.5.0 from 0.10.0 which includes explicit support for NativeAOT and trimming, with just a few changes.